### PR TITLE
[INJIMOB-2073] change wellknown api from /.well-known to /well-known-proxy

### DIFF
--- a/shared/api.ts
+++ b/shared/api.ts
@@ -29,7 +29,7 @@ export const API_URLS: ApiUrls = {
   issuerWellknownConfig: {
     method: 'GET',
     buildURL: (issuerId: string): `/${string}` =>
-      `/v1/mimoto/issuers/${issuerId}/.well-known`,
+      `/v1/mimoto/issuers/${issuerId}/well-known-proxy`,
   },
   allProperties: {
     method: 'GET',

--- a/shared/openId4VCI/Utils.ts
+++ b/shared/openId4VCI/Utils.ts
@@ -93,7 +93,7 @@ export const updateCredentialInformation = (
   return {
     verifiableCredential: {
       ...credential,
-      wellKnown: context.selectedIssuer['.well-known'],
+      wellKnown: context.selectedIssuer['wellknown_endpoint'],
       credentialConfigurationId: context.selectedCredentialType.id,
       issuerLogo: getDisplayObjectForCurrentLanguage(
         context.selectedIssuer.display,


### PR DESCRIPTION


## Description

> [INJIMOB-2073] change wellknown api from /.well-known to /well-known-proxy

## Issue ticket number and link

>[INJIMOB-2073](https://mosip.atlassian.net/browse/INJIMOB-2073&#41)




[INJIMOB-2073]: https://mosip.atlassian.net/browse/INJIMOB-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INJIMOB-2073]: https://mosip.atlassian.net/browse/INJIMOB-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ