### PR TITLE
[INJIMOB-2260] exclude org.bouncycastle:bcpkix-jdk15on from vcverifier

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -270,7 +270,9 @@ dependencies {
     implementation("io.mosip:tuvali:0.5.1")
     implementation("io.mosip:inji-vci-client:0.2.0-SNAPSHOT")
     implementation("com.google.code.gson:gson:2.10.1")
-    implementation("io.mosip:vcverifier-aar:1.2.0-SNAPSHOT")
+    implementation("io.mosip:vcverifier-aar:1.2.0-SNAPSHOT"){
+        exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
+    }
 
 
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";


### PR DESCRIPTION
vcverifier-aar having the transitive dependency org.bouncycastle:bcpkix-jdk15on:1.69 was conflicting with the other  dependency's transitive depndencies of inji-wallet, to resolve this issue "org.bouncycastle:bcpkix-jdk15on:1.69" is excluded from vcverifier-aar
<img width="739" alt="image" src="https://github.com/user-attachments/assets/d994ae04-c576-4148-8879-7a82b597691d">
