### PR TITLE
[INJIMOB-2241] fix error text overlap on host selection overlay screen

### DIFF
--- a/components/EditableListItem.tsx
+++ b/components/EditableListItem.tsx
@@ -59,7 +59,7 @@ export const EditableListItem: React.FC<EditableListItemProps> = props => {
           {props.items.map((item: ListItemProps, index) => {
             return (
               <React.Fragment key={index}>
-                <Text testID={item.testID + 'Label'}>
+                <Text testID={item.testID + 'Label'} style={{marginTop:10}}>
                   {t('editLabel', {label: item.label})}
                 </Text>
                 <Input

--- a/components/ui/themes/DefaultTheme.ts
+++ b/components/ui/themes/DefaultTheme.ts
@@ -929,7 +929,7 @@ export const DefaultTheme = {
     },
     error: {
       position: 'absolute',
-      top: 30,
+      top: 65,
       left: 5,
       color: Colors.Red,
       fontFamily: 'Inter_600SemiBold',

--- a/components/ui/themes/PurpleTheme.ts
+++ b/components/ui/themes/PurpleTheme.ts
@@ -939,7 +939,7 @@ export const PurpleTheme = {
     },
     error: {
       position: 'absolute',
-      top: 30,
+      top: 65,
       left: 5,
       color: Colors.Red,
       fontFamily: 'Inter_600SemiBold',

--- a/machines/settings.typegen.ts
+++ b/machines/settings.typegen.ts
@@ -18,7 +18,7 @@
           services: never;
         };
         eventsCausingActions: {
-          "requestStoredContext": "xstate.init";
+          "requestStoredContext": "BIOMETRIC_CANCELLED" | "xstate.init";
 "resetCredentialRegistryResponse": "CANCEL" | "UPDATE_HOST";
 "resetIsBiometricToggled": "DISMISS";
 "resetKeyOrderingResponse": "RESET_KEY_ORDER_RESPONSE";


### PR DESCRIPTION
## Description

> The alignment issue of the dialogue box during a error scenario has been fixed.

## Issue ticket number and link

> Example : [INJIMOB-2241](https://mosip.atlassian.net/browse/INJIMOB-2241&#41)




[INJIMOB-2241]: https://mosip.atlassian.net/browse/INJIMOB-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ