### PR TITLE
[INJIMOB-2538] fetch the openid4vp sharing flow client validation property from inji default properties file and pass it to library

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -51,10 +51,11 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void authenticateVerifier(String encodedAuthorizationRequest, ReadableArray trustedVerifiers,
+            Boolean clientValidation,
             Promise promise) {
         try {
             AuthorizationRequest authenticationResponse = openID4VP.authenticateVerifier(encodedAuthorizationRequest,
-                    convertReadableArrayToVerifierArray(trustedVerifiers));
+                    convertReadableArrayToVerifierArray(trustedVerifiers), clientValidation);
             String authenticationResponseAsJson = gson.toJson(authenticationResponse, AuthorizationRequest.class);
             promise.resolve(authenticationResponseAsJson);
         } catch (Exception exception) {

--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -51,11 +51,11 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void authenticateVerifier(String encodedAuthorizationRequest, ReadableArray trustedVerifiers,
-            Boolean clientValidation,
+            Boolean shouldValidateClient,
             Promise promise) {
         try {
             AuthorizationRequest authenticationResponse = openID4VP.authenticateVerifier(encodedAuthorizationRequest,
-                    convertReadableArrayToVerifierArray(trustedVerifiers), clientValidation);
+                    convertReadableArrayToVerifierArray(trustedVerifiers), shouldValidateClient);
             String authenticationResponseAsJson = gson.toJson(authenticationResponse, AuthorizationRequest.class);
             promise.resolve(authenticationResponseAsJson);
         } catch (Exception exception) {

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b82a714050e22d309e029aaffac33f021c04aac740f661a9879441a7d414f4f",
+  "originHash" : "178f6c7c607eeb08b99a4966015d08339500de64791888a2e79d6b7afae53659",
   "pins" : [
     {
       "identity" : "base45-swift",
@@ -34,7 +34,7 @@
       "location" : "https://github.com/mosip/inji-openid4vp-ios-swift",
       "state" : {
         "branch" : "develop",
-        "revision" : "20c1a6c314b73d303ce7c5f2b6ba94235dcb68ad"
+        "revision" : "10c161f4e7414e8a7b0dc2d52d3f4d8faf19b8d7"
       }
     },
     {
@@ -80,6 +80,15 @@
       "state" : {
         "branch" : "develop",
         "revision" : "96bc662cd07df051cf2357691469bba57b0217e8"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
+        "version" : "0.9.19"
       }
     }
   ],

--- a/ios/RNOpenID4VPModule.m
+++ b/ios/RNOpenID4VPModule.m
@@ -7,6 +7,7 @@ RCT_EXTERN_METHOD(init:(NSString *)appId)
 
 RCT_EXTERN_METHOD(authenticateVerifier:(NSString *)encodedAuthorizationRequest
                   trustedVerifierJSON:(id)trustedVerifierJSON
+                  clientValidation:(BOOL)clientValidation
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/RNOpenID4VPModule.m
+++ b/ios/RNOpenID4VPModule.m
@@ -7,7 +7,7 @@ RCT_EXTERN_METHOD(init:(NSString *)appId)
 
 RCT_EXTERN_METHOD(authenticateVerifier:(NSString *)encodedAuthorizationRequest
                   trustedVerifierJSON:(id)trustedVerifierJSON
-                  clientValidation:(BOOL)clientValidation
+                  shouldValidateClient:(BOOL)shouldValidateClient
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/RNOpenID4VPModule.swift
+++ b/ios/RNOpenID4VPModule.swift
@@ -19,7 +19,7 @@ class RNOpenId4VpModule: NSObject, RCTBridgeModule {
   @objc
   func authenticateVerifier(_ encodedAuthorizationRequest: String,
                             trustedVerifierJSON: AnyObject,
-                            clientValidation: Bool,
+                            shouldValidateClient: Bool,
                             resolver resolve: @escaping RCTPromiseResolveBlock,
                             rejecter reject: @escaping RCTPromiseRejectBlock) {
     Task {
@@ -37,7 +37,7 @@ class RNOpenId4VpModule: NSObject, RCTBridgeModule {
           return Verifier(clientId: clientId, responseUris: responseUris)
         }
         
-        let authenticationResponse: AuthorizationRequest = try await openID4VP!.authenticateVerifier(encodedAuthorizationRequest: encodedAuthorizationRequest, trustedVerifierJSON: trustedVerifiersList, clientValidation: clientValidation)
+        let authenticationResponse: AuthorizationRequest = try await openID4VP!.authenticateVerifier(encodedAuthorizationRequest: encodedAuthorizationRequest, trustedVerifierJSON: trustedVerifiersList, shouldValidateClient: shouldValidateClient)
         
         let response = try toJsonString(jsonObject: authenticationResponse)
         resolve(response)

--- a/ios/RNOpenID4VPModule.swift
+++ b/ios/RNOpenID4VPModule.swift
@@ -19,6 +19,7 @@ class RNOpenId4VpModule: NSObject, RCTBridgeModule {
   @objc
   func authenticateVerifier(_ encodedAuthorizationRequest: String,
                             trustedVerifierJSON: AnyObject,
+                            clientValidation: Bool,
                             resolver resolve: @escaping RCTPromiseResolveBlock,
                             rejecter reject: @escaping RCTPromiseRejectBlock) {
     Task {
@@ -36,7 +37,7 @@ class RNOpenId4VpModule: NSObject, RCTBridgeModule {
           return Verifier(clientId: clientId, responseUris: responseUris)
         }
         
-        let authenticationResponse: AuthorizationRequest = try await openID4VP!.authenticateVerifier(encodedAuthorizationRequest: encodedAuthorizationRequest, trustedVerifierJSON: trustedVerifiersList)
+        let authenticationResponse: AuthorizationRequest = try await openID4VP!.authenticateVerifier(encodedAuthorizationRequest: encodedAuthorizationRequest, trustedVerifierJSON: trustedVerifiersList, clientValidation: clientValidation)
         
         let response = try toJsonString(jsonObject: authenticationResponse)
         resolve(response)

--- a/machines/openID4VP/openID4VPGuards.ts
+++ b/machines/openID4VP/openID4VPGuards.ts
@@ -34,6 +34,6 @@ export const openID4VPGuards = () => {
     isFaceVerificationRetryAttempt: (context: any) =>
       context.isFaceVerificationRetryAttempt,
 
-    isClientValidationRequred: () => isClientValidationRequired(),
+    isClientValidationRequred: (_, event) => event.data,
   };
 };

--- a/machines/openID4VP/openID4VPGuards.ts
+++ b/machines/openID4VP/openID4VPGuards.ts
@@ -1,3 +1,4 @@
+import {isClientValidationRequired} from '../../shared/openID4VP/OpenID4VP';
 import {VCShareFlowType} from '../../shared/Utils';
 
 export const openID4VPGuards = () => {
@@ -32,5 +33,7 @@ export const openID4VPGuards = () => {
 
     isFaceVerificationRetryAttempt: (context: any) =>
       context.isFaceVerificationRetryAttempt,
+
+    isClientValidationRequred: () => isClientValidationRequired(),
   };
 };

--- a/machines/openID4VP/openID4VPMachine.ts
+++ b/machines/openID4VP/openID4VPMachine.ts
@@ -52,9 +52,15 @@ export const openID4VPMachine = model.createMachine(
         },
       },
       checkFaceAuthConsent: {
-        entry: 'getFaceAuthConsent',
+        entry: ['setIsShowLoadingScreen', 'getFaceAuthConsent'],
         on: {
-          STORE_RESPONSE: [
+          STORE_RESPONSE: {target: 'checkIfClientValidationIsRequired'},
+        },
+      },
+      checkIfClientValidationIsRequired: {
+        invoke: {
+          src: 'shouldValidateClient',
+          onDone: [
             {
               cond: 'isClientValidationRequred',
               actions: 'updateShowFaceAuthConsent',
@@ -68,7 +74,6 @@ export const openID4VPMachine = model.createMachine(
         },
       },
       getTrustedVerifiersList: {
-        entry: 'setIsShowLoadingScreen',
         invoke: {
           src: 'fetchTrustedVerifiers',
           onDone: {

--- a/machines/openID4VP/openID4VPMachine.ts
+++ b/machines/openID4VP/openID4VPMachine.ts
@@ -54,10 +54,17 @@ export const openID4VPMachine = model.createMachine(
       checkFaceAuthConsent: {
         entry: 'getFaceAuthConsent',
         on: {
-          STORE_RESPONSE: {
-            actions: 'updateShowFaceAuthConsent',
-            target: 'getTrustedVerifiersList',
-          },
+          STORE_RESPONSE: [
+            {
+              cond: 'isClientValidationRequred',
+              actions: 'updateShowFaceAuthConsent',
+              target: 'getTrustedVerifiersList',
+            },
+            {
+              actions: 'updateShowFaceAuthConsent',
+              target: 'getKeyPairFromKeystore',
+            },
+          ],
         },
       },
       getTrustedVerifiersList: {

--- a/machines/openID4VP/openID4VPMachine.typegen.ts
+++ b/machines/openID4VP/openID4VPMachine.typegen.ts
@@ -8,6 +8,11 @@ export interface Typegen0 {
       data: unknown;
       __tip: 'See the XState TS docs to learn how to strongly type this.';
     };
+    'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]': {
+      type: 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]';
+      data: unknown;
+      __tip: 'See the XState TS docs to learn how to strongly type this.';
+    };
     'done.invoke.OpenID4VP.checkKeyPair:invocation[0]': {
       type: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
       data: unknown;
@@ -57,6 +62,7 @@ export interface Typegen0 {
     getKeyPair: 'done.invoke.OpenID4VP.getKeyPairFromKeystore:invocation[0]';
     getSelectedKey: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
     sendVP: 'done.invoke.OpenID4VP.sendingVP:invocation[0]';
+    shouldValidateClient: 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]';
   };
   missingImplementations: {
     actions:
@@ -107,7 +113,8 @@ export interface Typegen0 {
       | 'getAuthenticationResponse'
       | 'getKeyPair'
       | 'getSelectedKey'
-      | 'sendVP';
+      | 'sendVP'
+      | 'shouldValidateClient';
   };
   eventsCausingActions: {
     compareAndStoreSelectedVC: 'SET_SELECTED_VC';
@@ -136,7 +143,7 @@ export interface Typegen0 {
     setFlowType: 'AUTHENTICATE';
     setIsFaceVerificationRetryAttempt: 'FACE_INVALID';
     setIsShareWithSelfie: 'AUTHENTICATE';
-    setIsShowLoadingScreen: 'STORE_RESPONSE';
+    setIsShowLoadingScreen: 'AUTHENTICATE';
     setMiniViewShareSelectedVC: 'AUTHENTICATE';
     setSelectedVCs: 'ACCEPT_REQUEST' | 'VERIFY_AND_ACCEPT_REQUEST';
     setSendVPShareError: 'error.platform.OpenID4VP.sendingVP:invocation[0]';
@@ -147,7 +154,7 @@ export interface Typegen0 {
     shareDeclineStatus: 'CONFIRM';
     storeShowFaceAuthConsent: 'FACE_VERIFICATION_CONSENT';
     updateFaceCaptureBannerStatus: 'FACE_VALID';
-    updateShowFaceAuthConsent: 'STORE_RESPONSE';
+    updateShowFaceAuthConsent: 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]';
   };
   eventsCausingDelays: {
     SHARING_TIMEOUT: 'CONFIRM' | 'FACE_VALID' | 'RETRY';
@@ -157,7 +164,7 @@ export interface Typegen0 {
       | 'FACE_VALID'
       | 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
     isAnyVCHasImage: 'CHECK_FOR_IMAGE';
-    isClientValidationRequred: 'STORE_RESPONSE';
+    isClientValidationRequred: 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]';
     isFaceVerificationRetryAttempt: 'FACE_INVALID';
     isSelectedVCMatchingRequest: 'CHECK_SELECTED_VC';
     isShareWithSelfie:
@@ -172,20 +179,22 @@ export interface Typegen0 {
     showFaceAuthConsentScreen: 'CONFIRM';
   };
   eventsCausingServices: {
-    fetchTrustedVerifiers: 'STORE_RESPONSE';
+    fetchTrustedVerifiers: 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]';
     getAuthenticationResponse: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
     getKeyPair:
-      | 'STORE_RESPONSE'
+      | 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]'
       | 'done.invoke.OpenID4VP.getTrustedVerifiersList:invocation[0]';
     getSelectedKey:
       | 'FACE_VALID'
       | 'done.invoke.OpenID4VP.getKeyPairFromKeystore:invocation[0]';
     sendVP: 'CONFIRM' | 'FACE_VALID' | 'RETRY';
+    shouldValidateClient: 'STORE_RESPONSE';
   };
   matchesStates:
     | 'authenticateVerifier'
     | 'checkFaceAuthConsent'
     | 'checkIfAnySelectedVCHasImage'
+    | 'checkIfClientValidationIsRequired'
     | 'checkIfMatchingVCsHasSelectedVC'
     | 'checkKeyPair'
     | 'faceVerificationConsent'

--- a/machines/openID4VP/openID4VPMachine.typegen.ts
+++ b/machines/openID4VP/openID4VPMachine.typegen.ts
@@ -80,7 +80,6 @@ export interface Typegen0 {
       | 'setFlowType'
       | 'setIsFaceVerificationRetryAttempt'
       | 'setIsShareWithSelfie'
-      | 'setIsShowLoadingScreen'
       | 'setMiniViewShareSelectedVC'
       | 'setSelectedVCs'
       | 'setSendVPShareError'
@@ -135,7 +134,6 @@ export interface Typegen0 {
     setFlowType: 'AUTHENTICATE';
     setIsFaceVerificationRetryAttempt: 'FACE_INVALID';
     setIsShareWithSelfie: 'AUTHENTICATE';
-    setIsShowLoadingScreen: 'STORE_RESPONSE';
     setMiniViewShareSelectedVC: 'AUTHENTICATE';
     setSelectedVCs: 'ACCEPT_REQUEST' | 'VERIFY_AND_ACCEPT_REQUEST';
     setSendVPShareError: 'error.platform.OpenID4VP.sendingVP:invocation[0]';
@@ -170,9 +168,11 @@ export interface Typegen0 {
     showFaceAuthConsentScreen: 'CONFIRM';
   };
   eventsCausingServices: {
-    fetchTrustedVerifiers: 'STORE_RESPONSE';
+    fetchTrustedVerifiers: never;
     getAuthenticationResponse: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
-    getKeyPair: 'done.invoke.OpenID4VP.getTrustedVerifiersList:invocation[0]';
+    getKeyPair:
+      | 'STORE_RESPONSE'
+      | 'done.invoke.OpenID4VP.getTrustedVerifiersList:invocation[0]';
     getSelectedKey:
       | 'FACE_VALID'
       | 'done.invoke.OpenID4VP.getKeyPairFromKeystore:invocation[0]';

--- a/machines/openID4VP/openID4VPMachine.typegen.ts
+++ b/machines/openID4VP/openID4VPMachine.typegen.ts
@@ -80,6 +80,7 @@ export interface Typegen0 {
       | 'setFlowType'
       | 'setIsFaceVerificationRetryAttempt'
       | 'setIsShareWithSelfie'
+      | 'setIsShowLoadingScreen'
       | 'setMiniViewShareSelectedVC'
       | 'setSelectedVCs'
       | 'setSendVPShareError'
@@ -95,6 +96,7 @@ export interface Typegen0 {
     guards:
       | 'hasKeyPair'
       | 'isAnyVCHasImage'
+      | 'isClientValidationRequred'
       | 'isFaceVerificationRetryAttempt'
       | 'isSelectedVCMatchingRequest'
       | 'isShareWithSelfie'
@@ -134,6 +136,7 @@ export interface Typegen0 {
     setFlowType: 'AUTHENTICATE';
     setIsFaceVerificationRetryAttempt: 'FACE_INVALID';
     setIsShareWithSelfie: 'AUTHENTICATE';
+    setIsShowLoadingScreen: 'STORE_RESPONSE';
     setMiniViewShareSelectedVC: 'AUTHENTICATE';
     setSelectedVCs: 'ACCEPT_REQUEST' | 'VERIFY_AND_ACCEPT_REQUEST';
     setSendVPShareError: 'error.platform.OpenID4VP.sendingVP:invocation[0]';
@@ -154,6 +157,7 @@ export interface Typegen0 {
       | 'FACE_VALID'
       | 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
     isAnyVCHasImage: 'CHECK_FOR_IMAGE';
+    isClientValidationRequred: 'STORE_RESPONSE';
     isFaceVerificationRetryAttempt: 'FACE_INVALID';
     isSelectedVCMatchingRequest: 'CHECK_SELECTED_VC';
     isShareWithSelfie:
@@ -168,7 +172,7 @@ export interface Typegen0 {
     showFaceAuthConsentScreen: 'CONFIRM';
   };
   eventsCausingServices: {
-    fetchTrustedVerifiers: never;
+    fetchTrustedVerifiers: 'STORE_RESPONSE';
     getAuthenticationResponse: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
     getKeyPair:
       | 'STORE_RESPONSE'

--- a/machines/openID4VP/openID4VPServices.ts
+++ b/machines/openID4VP/openID4VPServices.ts
@@ -3,6 +3,7 @@ import {fetchKeyPair} from '../../shared/cryptoutil/cryptoUtil';
 import {hasKeyPair} from '../../shared/openId4VCI/Utils';
 import {
   constructProofJWT,
+  isClientValidationRequired,
   OpenID4VP,
   OpenID4VP_Domain,
   OpenID4VP_Proof_Algo_Type,
@@ -12,6 +13,10 @@ export const openID4VPServices = () => {
   return {
     fetchTrustedVerifiers: async () => {
       return await CACHED_API.fetchTrustedVerifiersList();
+    },
+
+    shouldValidateClient: async () => {
+      return await isClientValidationRequired();
     },
 
     getAuthenticationResponse: (context: any) => async () => {

--- a/shared/openID4VP/OpenID4VP.ts
+++ b/shared/openID4VP/OpenID4VP.ts
@@ -20,14 +20,13 @@ export class OpenID4VP {
     encodedAuthorizationRequest: string,
     trustedVerifiersList: any,
   ) {
-    const config = await getAllConfigurations();
-    const validateClient = config.openid4vpClientValidation === 'true';
+    const shouldValidateClient = await isClientValidationRequired();
 
     const authenticationResponse =
       await OpenID4VP.InjiOpenID4VP.authenticateVerifier(
         encodedAuthorizationRequest,
         trustedVerifiersList,
-        validateClient,
+        shouldValidateClient,
       );
     return JSON.parse(authenticationResponse);
   }
@@ -93,4 +92,9 @@ function createJwtPayload(vpToken: {[key: string]: any}) {
     id,
     holder,
   };
+}
+
+export async function isClientValidationRequired() {
+  const config = await getAllConfigurations();
+  return config.openid4vpClientValidation === 'true';
 }

--- a/shared/openID4VP/OpenID4VP.ts
+++ b/shared/openID4VP/OpenID4VP.ts
@@ -21,11 +21,13 @@ export class OpenID4VP {
     trustedVerifiersList: any,
   ) {
     const config = await getAllConfigurations();
+    const validateClient = config.openid4vpClientValidation === 'true';
+
     const authenticationResponse =
       await OpenID4VP.InjiOpenID4VP.authenticateVerifier(
         encodedAuthorizationRequest,
         trustedVerifiersList,
-        Boolean(config.openid4vpClientValidation),
+        validateClient,
       );
     return JSON.parse(authenticationResponse);
   }

--- a/shared/openID4VP/OpenID4VP.ts
+++ b/shared/openID4VP/OpenID4VP.ts
@@ -3,6 +3,7 @@ import {__AppId} from '../GlobalVariables';
 import {VC} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
 import {getJWT} from '../cryptoutil/cryptoUtil';
 import {getJWK} from '../openId4VCI/Utils';
+import getAllConfigurations from '../api';
 
 export const OpenID4VP_Key_Ref = 'OpenID4VP_KeyPair';
 export const OpenID4VP_Proof_Algo_Type = 'RsaSignature2018';
@@ -19,10 +20,12 @@ export class OpenID4VP {
     encodedAuthorizationRequest: string,
     trustedVerifiersList: any,
   ) {
+    const config = await getAllConfigurations();
     const authenticationResponse =
       await OpenID4VP.InjiOpenID4VP.authenticateVerifier(
         encodedAuthorizationRequest,
         trustedVerifiersList,
+        config.openid4vpClientValidation,
       );
     return JSON.parse(authenticationResponse);
   }

--- a/shared/openID4VP/OpenID4VP.ts
+++ b/shared/openID4VP/OpenID4VP.ts
@@ -25,7 +25,7 @@ export class OpenID4VP {
       await OpenID4VP.InjiOpenID4VP.authenticateVerifier(
         encodedAuthorizationRequest,
         trustedVerifiersList,
-        config.openid4vpClientValidation,
+        Boolean(config.openid4vpClientValidation),
       );
     return JSON.parse(authenticationResponse);
   }


### PR DESCRIPTION
## Description

> Wallet will fetch the openid4vp client validation property and pass it to the libraries and based on this value libraries will decide whether it should perform the client validation or not.

## Issue ticket number and link

> Example : [INJIMOB-2538](https://mosip.atlassian.net/browse/INJIMOB-2538)


[INJIMOB-2538]: https://mosip.atlassian.net/browse/INJIMOB-2538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ