### PR TITLE
[INJIMOB-2471] set UUID as vc identifier

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -2,7 +2,7 @@ fileignoreconfig:
   - filename: package.json
     checksum: 5b4fcb5ddc7cc96cc2d1733b544d56ea66e88cdab995a1052fbf9ac0e9c2dc21
   - filename: package-lock.json
-    checksum: e448b633936de692ebdbadfac3a5a1ae3c2a2a55a8cc3ea7440bd5ec1dd9cef5
+    checksum: 8925d62a7011241371e295553f7bbe1af468c7f3f4d051436a30c8885a12d0a5
   - filename: lib/jsonld-signatures/suites/ed255192018/ed25519.ts
     checksum: 493b6e31144116cb612c24d98b97d8adcad5609c0a52c865a6847ced0a0ddc3a
   - filename: components/PasscodeVerify.tsx
@@ -344,7 +344,7 @@ fileignoreconfig:
     checksum: e1814f6ac8fe15794f26e96de887bc196ffcb37b434d46ffb69a9497d2683667
   - filename: injitest/src/main/resources/Vids.json
     checksum: 8bcffed7a6dd565ae695e1b29de0655e10bd5c5420af2718defd593a687b8817
-  - filename: injitest/src/main/java/inji/utils/UpdateNetworkSettings.java     
+  - filename: injitest/src/main/java/inji/utils/UpdateNetworkSettings.java
     checksum: e249ce3e6b7f47abc183fe5a3637bb39ccb06900ef75b9b2f08426d1535e22aa
   - filename: App.tsx
     checksum: d16d4a40b246abe25a5d2da7ec65163b5756fe8ba9390608a7fc7f8e721b2ed1
@@ -358,8 +358,8 @@ fileignoreconfig:
     checksum: c91348eceec5edbffa03ba03f3f52a8e90ff7f942816c9609080d1647052fd66
   - filename: ios/RNPixelpassModule.swift
     checksum: 822a2421798d5c0669f4ab1b983194eb770cbef2aa30bf212d06bd959738c4ca
-  - filename: injitest/src/test/java/androidTestCases/VerifyHistoryTest.java   
-    checksum: dffc4741b251b42c81d5bdac7d649c02b37bb9045285590b29f86c2d5f526fd1 
+  - filename: injitest/src/test/java/androidTestCases/VerifyHistoryTest.java
+    checksum: dffc4741b251b42c81d5bdac7d649c02b37bb9045285590b29f86c2d5f526fd1
   - filename: android/app/src/main/java/io/mosip/residentapp/RNPixelpassModule.java
     checksum: cef9be4bfafb54e2c885b2459f2819554cad6448b5dc372976706894df704e5d
   - filename: android/app/src/main/AndroidManifest.xml
@@ -372,7 +372,7 @@ fileignoreconfig:
     checksum: 947b6d75543e2bf959ca2d95dd7224051e0b4ec2c28f7515f923701e22a932f0
   - filename: components/FaceScanner/LivenessDetection.tsx
     checksum: d4140a42ee9ca0f7c90e490f762d181a723fd9dd20db891cbbe53bfbd8f81632
-  - filename: machines/VerifiableCredential/VCItemMachine/VCItemActions.ts       
+  - filename: machines/VerifiableCredential/VCItemMachine/VCItemActions.ts
     checksum: bc11e275227ccf93c5e869b47bb2b63454758983b8fc0e105004fefa1b169091
   - filename: machines/app.ts
     checksum: 5da59bb384d04e29c7745d773108903fa144275c57edc1aca1898fcae7baea84

--- a/.talismanrc
+++ b/.talismanrc
@@ -268,7 +268,7 @@ fileignoreconfig:
   - filename: machines/Issuers/IssuersGuards.ts
     checksum: 21783a057207ad04facdb4c71884f49b0230490def04158419d730e0cc60eb83
   - filename: machines/Issuers/IssuersActions.ts
-    checksum: 4414aa10588d2305293b1902982c5969895c858355e4b91d01dfaa8601c2dd62
+    checksum: 03949a8a7f66f9b94a57b6b817b6c425e8438a7c796d75c00692d030342102b1
   - filename: injitest/automation_trigger.sh
     checksum: f2f34839c99cb1b871dde17aed8508a071345d22738796e005ff709d2dab8644
   - filename: machines/Issuers/IssuersService.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -156,7 +156,7 @@ fileignoreconfig:
   - filename: injitest/README.md
     checksum: 82974a6b9363512472272245e9b433f92e63377e58ba306980876b745181a09c
   - filename: shared/VCMetadata.ts
-    checksum: 4c0f2acc58894e5a427e1317b38d04daff91f64d1e61d6ee2f246ee516ef97ca
+    checksum: c76bd3c825931ac241d8e4f76b8a7444789f49e3b4e45a599b4dcd574f7971c8
   - filename: ios/Podfile.lock
     checksum: 43bd4742f2ba13357d8b9c44430bfa3cca0bf9bf8341984fd81174a929c85955
   - filename: components/BackupAndRestoreBannerNotification.tsx

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -155,11 +155,7 @@ export const IssuersActions = (model: any) => {
     },
 
     storeVerifiableCredentialMeta: send(
-      context =>
-        StoreEvents.PREPEND(
-          MY_VCS_STORE_KEY,
-          getVCMetadata(context, context.keyType),
-        ),
+      context => StoreEvents.PREPEND(MY_VCS_STORE_KEY, context.vcMetadata),
       {
         to: (context: any) => context.serviceRefs.store,
       },
@@ -180,7 +176,7 @@ export const IssuersActions = (model: any) => {
 
     storeVerifiableCredentialData: send(
       (context: any) => {
-        const vcMetadata = getVCMetadata(context, context.keyType);
+        const vcMetadata = context.vcMetadata;
         const {
           verifiableCredential: {
             processedCredential,
@@ -206,7 +202,7 @@ export const IssuersActions = (model: any) => {
       context => {
         return {
           type: 'VC_ADDED',
-          vcMetadata: getVCMetadata(context, context.keyType),
+          vcMetadata: context.vcMetadata,
         };
       },
       {
@@ -218,7 +214,7 @@ export const IssuersActions = (model: any) => {
       (context: any) => {
         return {
           type: 'VC_DOWNLOADED',
-          vcMetadata: getVCMetadata(context, context.keyType),
+          vcMetadata: context.vcMetadata,
           vc: context.credentialWrapper,
         };
       },
@@ -293,7 +289,7 @@ export const IssuersActions = (model: any) => {
 
     logDownloaded: send(
       context => {
-        const vcMetadata = getVCMetadata(context, context.keyType);
+        const vcMetadata = context.vcMetadata;
         return ActivityLogEvents.LOG_ACTIVITY(
           VCActivityLog.getLogFromObject({
             _vcKey: vcMetadata.getVcKey(),

--- a/machines/VerifiableCredential/VCItemMachine/VCItemActions.ts
+++ b/machines/VerifiableCredential/VCItemMachine/VCItemActions.ts
@@ -1,5 +1,5 @@
 import {assign, send} from 'xstate';
-import {CommunicationDetails} from '../../../shared/Utils';
+import {CommunicationDetails, UUID} from '../../../shared/Utils';
 import {StoreEvents} from '../../store';
 import {VCMetadata} from '../../../shared/VCMetadata';
 import {MIMOTO_BASE_URL, MY_VCS_STORE_KEY} from '../../../shared/constants';
@@ -124,11 +124,8 @@ export const VCItemActions = model => {
     setContext: model.assign((context, event) => {
       const vcMetadata = VCMetadata.fromVC(context.vcMetadata);
       if (!vcMetadata.id) {
-        const verifiableCredentialId = event.response.verifiableCredential.id;
-        const credId = verifiableCredentialId.startsWith('did')
-          ? verifiableCredentialId.split(':')
-          : verifiableCredentialId.split('/');
-        vcMetadata.id = `${credId[credId.length - 1]} - ${vcMetadata.issuer}`;
+          const credId = UUID.generate();
+        vcMetadata.id = `${credId}_${vcMetadata.issuer}`;
       }
       return {
         ...context,

--- a/machines/VerifiableCredential/VCMetaMachine/vc.d.ts
+++ b/machines/VerifiableCredential/VCMetaMachine/vc.d.ts
@@ -43,22 +43,24 @@ export interface CredentialSubject {
 
 type VCContext = (string | Record<string, unknown>)[];
 
-export type Credential = {
-  credentialConfigurationId: any;
-  '@context': VCContext;
-  credentialSubject: CredentialSubject;
-  id: string;
-  issuanceDate: string;
-  issuer: string;
-  proof: {
-    created: string;
-    jws: string;
-    proofPurpose: 'assertionMethod' | string;
-    type: 'RsaSignature2018' | string;
-    verificationMethod: string;
-  };
-  type: string[];
-} | string
+export type Credential =
+  | {
+      credentialConfigurationId: any;
+      '@context': VCContext;
+      credentialSubject: CredentialSubject;
+      id: string;
+      issuanceDate: string;
+      issuer: string;
+      proof: {
+        created: string;
+        jws: string;
+        proofPurpose: 'assertionMethod' | string;
+        type: 'RsaSignature2018' | string;
+        verificationMethod: string;
+      };
+      type: string[];
+    }
+  | string;
 
 export interface VerifiableCredential {
   issuerLogo: logoType;
@@ -81,7 +83,6 @@ export interface VerifiableCredentialData {
 export interface CredentialWrapper {
   verifiableCredential: VerifiableCredential;
   format: string;
-  identifier: string;
   generatedOn: Date;
   vcMetadata: VCMetadata;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "simple-pem2jwk": "^0.2.4",
         "telemetry-sdk": "git://github.com/mosip/sunbird-telemetry-sdk.git#f762be5732ee552c0c70bdd540aa4e2701554c71",
         "text-encoding": "^0.7.0",
+        "uuid": "^11.0.3",
         "xstate": "^4.35.0"
       },
       "devDependencies": {
@@ -14126,6 +14127,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/expo-auth-session/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/expo-barcode-scanner": {
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-12.3.2.tgz",
@@ -14161,6 +14172,16 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-constants/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/expo-crypto": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-12.6.0.tgz",
@@ -14194,6 +14215,16 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-file-system/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/expo-font": {
@@ -14395,6 +14426,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/expo-linking/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/expo-local-authentication": {
@@ -14878,6 +14919,16 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/expo/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/extend": {
@@ -29274,12 +29325,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -40399,6 +40454,11 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
           "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -40561,6 +40621,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -40587,6 +40652,13 @@
       "requires": {
         "@expo/config": "~8.1.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "expo-crypto": {
@@ -40614,6 +40686,13 @@
       "integrity": "sha512-xy61KaTaDgXhT/dllwYDHm3ch026EyO8j4eC6wSVr/yE12MMMxAC09yGwy4f7kkOs6ztGVQF5j7ldRzNLN4l0Q==",
       "requires": {
         "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "expo-font": {
@@ -40773,6 +40852,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -51856,9 +51940,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "simple-pem2jwk": "^0.2.4",
     "telemetry-sdk": "git://github.com/mosip/sunbird-telemetry-sdk.git#f762be5732ee552c0c70bdd540aa4e2701554c71",
     "text-encoding": "^0.7.0",
+    "uuid": "^11.0.3",
     "xstate": "^4.35.0"
   },
   "devDependencies": {

--- a/shared/Utils.ts
+++ b/shared/Utils.ts
@@ -1,7 +1,8 @@
-import { VCMetadata } from './VCMetadata';
-import { NETWORK_REQUEST_FAILED } from './constants';
-import { groupBy } from './javascript';
-import { Issuers } from './openId4VCI/Utils';
+import {VCMetadata} from './VCMetadata';
+import {NETWORK_REQUEST_FAILED} from './constants';
+import {groupBy} from './javascript';
+import {Issuers} from './openId4VCI/Utils';
+import {v4 as uuid} from 'uuid';
 
 export const getVCsOrderedByPinStatus = (vcMetadatas: VCMetadata[]) => {
   const [pinned, unpinned] = groupBy(
@@ -54,3 +55,9 @@ export const parseJSON = (input: any) => {
 export const isNetworkError = (error: string) => {
   return error.includes(NETWORK_REQUEST_FAILED);
 };
+
+export class UUID {
+  public static generate(): string {
+    return uuid();
+  }
+}

--- a/shared/VCMetadata.ts
+++ b/shared/VCMetadata.ts
@@ -131,7 +131,7 @@ export function parseMetadatas(metadataStrings: object[]) {
 
 export const getVCMetadata = (context: object, keyType: string) => {
   const issuer = context.selectedIssuer.credential_issuer;
-  const credentialId = context.vcMetadata.id || `${UUID.generate()}_${issuer}`;
+  const credentialId = `${UUID.generate()}_${issuer}`;
 
   return VCMetadata.fromVC({
     requestId: credentialId,

--- a/shared/VCMetadata.ts
+++ b/shared/VCMetadata.ts
@@ -14,6 +14,11 @@ import {getCredentialType} from '../components/VC/common/VCUtils';
 const VC_KEY_PREFIX = 'VC';
 const VC_ITEM_STORE_KEY_REGEX = '^VC_[a-zA-Z0-9_-]+$';
 
+/** TODO: two identifiers requestId and id
+ * we have 2 fields in metadata - id, requestID
+ * requestID -> This will be holding the requestId required for OTP flow VCs and for OIDC flow it holds the generated UUID
+ * id        -> holds UUID for both OTP based & OIDC flow
+ */
 export class VCMetadata {
   static vcKeyRegExp = new RegExp(VC_ITEM_STORE_KEY_REGEX);
   idType: VcIdType | string = '';
@@ -111,8 +116,8 @@ export class VCMetadata {
   // Update VC_ITEM_STORE_KEY_REGEX in case of changes in vckey
   getVcKey(): string {
     return this.timestamp !== ''
-      ? `${VC_KEY_PREFIX}_${this.timestamp}_${this.requestId}`
-      : `${VC_KEY_PREFIX}_${this.requestId}`;
+      ? `${VC_KEY_PREFIX}_${this.timestamp}_${this.id}`
+      : `${VC_KEY_PREFIX}_${this.id}`;
   }
 
   equals(other: VCMetadata): boolean {

--- a/shared/VCMetadata.ts
+++ b/shared/VCMetadata.ts
@@ -8,7 +8,7 @@ import {
 import {Protocols} from './openId4VCI/Utils';
 import {getMosipIdentifier} from './commonUtil';
 import {VCFormat} from './VCFormat';
-import {isMosipVC} from './Utils';
+import {isMosipVC, UUID} from './Utils';
 import {getCredentialType} from '../components/VC/common/VCUtils';
 
 const VC_KEY_PREFIX = 'VC';
@@ -129,21 +129,15 @@ export function parseMetadatas(metadataStrings: object[]) {
   return metadataStrings.map(o => new VCMetadata(o));
 }
 
-export const getVCMetadata = (
-  context: object,
-  keyType: string,
-  credType: CredentialTypes,
-) => {
-  const [issuer, protocol, credentialId] =
-    context.credentialWrapper?.identifier.split(':');
+export const getVCMetadata = (context: object, keyType: string) => {
+  const issuer = context.selectedIssuer.credential_issuer;
+  const credentialId = context.vcMetadata.id || `${UUID.generate()}_${issuer}`;
 
-  //TODO: Can we get the issuer and protocol as context.selectedIssuer.credential_issuer  and context.selectedIssuer.protocol respectively?
-  // This will avoid setting identifier field in credential wrapper and splitting it to get the details
   return VCMetadata.fromVC({
-    requestId: credentialId ?? null,
+    requestId: credentialId,
     issuer: issuer,
-    protocol: protocol,
-    id: `${credentialId}_${issuer}`,
+    protocol: context.selectedIssuer.protocol,
+    id: credentialId,
     timestamp: context.timestamp ?? '',
     isVerified: context.vcMetadata.isVerified ?? false,
     isExpired: context.vcMetadata.isExpired ?? false,

--- a/shared/VCMetadata.ts
+++ b/shared/VCMetadata.ts
@@ -132,11 +132,13 @@ export const getVCMetadata = (
   const [issuer, protocol, credentialId] =
     context.credentialWrapper?.identifier.split(':');
 
+  //TODO: Can we get the issuer and protocol as context.selectedIssuer.credential_issuer  and context.selectedIssuer.protocol respectively?
+  // This will avoid setting identifier field in credential wrapper and splitting it to get the details
   return VCMetadata.fromVC({
     requestId: credentialId ?? null,
     issuer: issuer,
     protocol: protocol,
-    id: `${credentialId} + '_' + ${issuer}`,
+    id: `${credentialId}_${issuer}`,
     timestamp: context.timestamp ?? '',
     isVerified: context.vcMetadata.isVerified ?? false,
     isExpired: context.vcMetadata.isExpired ?? false,

--- a/shared/VCMetadata.ts
+++ b/shared/VCMetadata.ts
@@ -1,6 +1,5 @@
 import {
   Credential,
-  CredentialTypes,
   VC,
   VcIdType,
   VerifiableCredential,

--- a/shared/openId4VCI/Utils.ts
+++ b/shared/openId4VCI/Utils.ts
@@ -70,21 +70,6 @@ export const isActivationNeeded = (issuer: string) => {
 
 export const Issuers_Key_Ref = 'OpenId4VCI_KeyPair';
 
-export const getIdentifier = (
-  context,
-  credential: VerifiableCredential,
-  format: string,
-) => {
-  const credId = UUID.generate();
-  return (
-    context.selectedIssuer.issuer_id +
-    ':' +
-    context.selectedIssuer.protocol +
-    ':' +
-    credId
-  );
-};
-
 export const updateCredentialInformation = async (
   context,
   credential: VerifiableCredential,
@@ -108,11 +93,6 @@ export const updateCredentialInformation = async (
   return {
     verifiableCredential,
     format: context.selectedCredentialType.format,
-    identifier: getIdentifier(
-      context,
-      verifiableCredential,
-      context.selectedCredentialType.format,
-    ),
     generatedOn: new Date(),
     vcMetadata: {
       ...context.vcMetadata,


### PR DESCRIPTION
## Description

Previously, credential ID was used as a unique identifier of the VC in the wallet. But as per spec credential ID field is optional, to remove this dependency, Wallet will use a generated UUID  as the unique identifier for the VC. A UUID is generated on download which serves as identifier

`VC id = ${UUID}_${issuer}`

## Issue ticket number and link

> [INJIMOB-2471](https://mosip.atlassian.net/browse/INJIMOB-2471)



[INJIMOB-2471]: https://mosip.atlassian.net/browse/INJIMOB-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


Note: Tested VC download, Activation, QR login, backup / restore, share scenarios for sanity