### PR TITLE
[INJIMOB-2878] modify ios/fastfile and internal build workflow to enable automation build without testflight deploy

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -171,7 +171,7 @@ jobs:
       APP_FLAVOR: ${{ inputs.injiFlavor }}
       SERVICE_LOCATION: '.'
       IOS_SERVICE_LOCATION: 'ios'
-      SCRIPT_NAME: ${{ inputs.enable_auth == 'true' && 'fastlane beta' || 'fastlane ios_ui_automation_build' }}
+      SCRIPT_NAME: 'fastlane beta'
       IOS_ARTIFACT_NAME: "ios-artifacts"
       IOS_ARTIFACT_PATH: "ios/fastlane/Inji_artifacts/"
     secrets:

--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -74,10 +74,10 @@ on:
         options:
           - false
           - true
-      liveness_detection:
-        description: 'Detect Liveness'
+      enable_auth:
+        description: 'Enable Authentication'
         required: true
-        default: 'false'
+        default: 'true'
         type: choice
         options:
           - false
@@ -112,7 +112,7 @@ jobs:
       APPLICATION_THEME: ${{ inputs.theme }}
       BUILD_DESCRIPTION: ${{ inputs.buildName }}
       ALLOW_ENV_EDIT: ${{ inputs.allow_env_edit }}
-      LIVENESS_DETECTION: ${{ inputs.liveness_detection }}
+      LIVENESS_DETECTION: 'false'
       APP_FLAVOR: ${{ inputs.injiFlavor }}
       SERVICE_LOCATION: '.'
       ANDROID_SERVICE_LOCATION: 'android'
@@ -166,11 +166,12 @@ jobs:
       TESTFLIGHT_BETA_APP_DESCRIPTION: ${{ inputs.buildName }}
       ALLOW_ENV_EDIT: ${{ inputs.allow_env_edit }}
       LIVENESS_DETECTION: ${{ inputs.liveness_detection }}
+      ENABLE_AUTH: ${{ inputs.enable_auth }}
       TESTFLIGHT_INTERNAL_TESTERS_GROUP: ${{ inputs.internal-testers }}
       APP_FLAVOR: ${{ inputs.injiFlavor }}
       SERVICE_LOCATION: '.'
       IOS_SERVICE_LOCATION: 'ios'
-      SCRIPT_NAME: "fastlane beta"
+      SCRIPT_NAME: ${{ inputs.enable_auth == 'true' && 'fastlane beta' || 'fastlane ios_ui_automation_build' }}
       IOS_ARTIFACT_NAME: "ios-artifacts"
       IOS_ARTIFACT_PATH: "ios/fastlane/Inji_artifacts/"
     secrets:

--- a/.github/workflows/ios-custom-build.yml
+++ b/.github/workflows/ios-custom-build.yml
@@ -1,0 +1,92 @@
+name: Build iOS App
+run-name: ${{ inputs.buildName }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      buildName:
+        description: 'Build App For'
+        required: true
+        default: 'Sprint-x/QA-Inji/Release-x.x.x'
+        type: string
+      mimotoBackendServiceUrl:
+        description: 'Mimoto backend service URL'
+        required: true
+        default: 'https://api.sandbox.mosip.net'
+        type: string
+      esignetBackendServiceUrl:
+        description: 'Esignet backend service URL'
+        required: true
+        default: 'https://api.sandbox.mosip.net'
+        type: string
+      injiFlavor:
+        description: 'Select Inji flavor'
+        required: true
+        default: 'Inji'
+        type: choice
+        options:
+          - residentapp
+          - inji
+          - collab
+          - synergy
+          - mec
+      theme:
+        description: 'Application Theme'
+        required: true
+        default: 'gradient'
+        type: choice
+        options:
+          - gradient
+          - purple
+      allow_env_edit:
+        description: 'Edit ENV'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - false
+          - true
+      enable_auth:
+        description: 'Enable Authentication'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - false
+          - true
+
+jobs:
+  build-ios:
+    uses: mosip/kattu/.github/workflows/ios-publish.yml@master
+    with:
+      NODE_VERSION: '18.x'
+      MIMOTO_HOST: ${{ inputs.mimotoBackendServiceUrl }}
+      ESIGNET_HOST: ${{ inputs.esignetBackendServiceUrl }}
+      APPLICATION_THEME: ${{ inputs.theme }}
+      TESTFLIGHT_BETA_APP_DESCRIPTION: ${{ inputs.buildName }}
+      ALLOW_ENV_EDIT: ${{ inputs.allow_env_edit }}
+      LIVENESS_DETECTION: 'false'
+      ENABLE_AUTH: ${{ inputs.enable_auth }}
+      TESTFLIGHT_INTERNAL_TESTERS_GROUP: 'Dev-testing'
+      APP_FLAVOR: ${{ inputs.injiFlavor }}
+      SERVICE_LOCATION: '.'
+      IOS_SERVICE_LOCATION: 'ios'
+      SCRIPT_NAME: "fastlane ios_ui_automation_build"
+      IOS_ARTIFACT_NAME: "ios-artifacts"
+      IOS_ARTIFACT_PATH: "ios/fastlane/Inji_artifacts/"
+    secrets:
+      APP_STORE_CONNECT_TEAM_ID: '${{ secrets.APP_STORE_CONNECT_TEAM_ID }}'
+      DEVELOPER_APP_ID: '${{ secrets.IOS_INJI_DEVELOPER_APP_ID }}'
+      INJI_IOS_DEVELOPER_APP_IDENTIFIER: '${{ secrets.INJI_IOS_DEVELOPER_APP_IDENTIFIER }}'
+      INJI_IOS_DEVELOPER_PORTAL_TEAM_ID: '${{ secrets.INJI_IOS_DEVELOPER_PORTAL_TEAM_ID }}'
+      INJI_IOS_FASTLANE_APPLE_ID: '${{ secrets.INJI_IOS_FASTLANE_APPLE_ID }}'
+      INJI_IOS_FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: '${{ secrets.INJI_IOS_FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}'
+      GIT_AUTHORIZATION: '${{ secrets.GIT_AUTHORIZATION }}'
+      INJI_IOS_PROVISIONING_PROFILE_SPECIFIER: '${{ secrets.INJI_IOS_PROVISIONING_PROFILE_SPECIFIER }}'
+      INJI_IOS_TEMP_KEYCHAIN_PASSWORD: '${{ secrets.INJI_IOS_TEMP_KEYCHAIN_PASSWORD }}'
+      INJI_IOS_TEMP_KEYCHAIN_USER: '${{ secrets.INJI_IOS_TEMP_KEYCHAIN_USER }}'
+      APPLE_KEY_ID: '${{ secrets.APPLE_KEY_ID }}'
+      APPLE_ISSUER_ID: '${{ secrets.APPLE_ISSUER_ID }}'
+      APPLE_KEY_CONTENT: '${{ secrets.APPLE_KEY_CONTENT }}'
+      MATCH_PASSWORD: '${{ secrets.INJI_IOS_MATCH_PASSWORD }}'
+      SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}'

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -102,7 +102,7 @@ platform :ios do
     keychain_name = TEMP_KEYCHAIN_USER
     keychain_password = TEMP_KEYCHAIN_PASSWORD
     ensure_temp_keychain(keychain_name, keychain_password)
-
+  
     api_key = app_store_connect_api_key(
       key_id: "#{APPLE_KEY_ID}",
       issuer_id: "#{APPLE_ISSUER_ID}",
@@ -111,7 +111,7 @@ platform :ios do
       in_house: false,
       is_key_content_base64: true
     )
-
+  
     match(
       type: 'appstore',
       app_identifier: "#{generate_app_bundle_id}",
@@ -129,18 +129,18 @@ platform :ios do
       workspace: "Inji.xcworkspace",
       scheme: "Inji",
       export_method: "app-store",
-
+      output_directory: "./fastlane/Inji_artifacts", 
+      output_name: "#{generate_app_name}.ipa",
       export_options: {
         provisioningProfiles: {
           "#{generate_app_bundle_id}" => "match AppStore #{generate_app_bundle_id}"
         }
       }
     )
-
+  
     delete_temp_keychain(keychain_name)
-
   end
-
+  
   lane :beta do
     keychain_name = TEMP_KEYCHAIN_USER
     keychain_password = TEMP_KEYCHAIN_PASSWORD


### PR DESCRIPTION


## Description

> modify ios/fastfile and internal build workflow to enable automation build without testflight deploy

## Issue ticket number and link

> Example : [INJIMOB-2878](https://mosip.atlassian.net/browse/INJIMOB-2878&#41)



[INJIMOB-2878]: https://mosip.atlassian.net/browse/INJIMOB-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ