### PR TITLE
[INJIMOB-2575] qr-login log in vc-activity log

### DIFF
--- a/machines/bleShare/scan/scanActions.ts
+++ b/machines/bleShare/scan/scanActions.ts
@@ -337,7 +337,7 @@ export const ScanActions = (model: any) => {
 
         return ActivityLogEvents.LOG_ACTIVITY(
           VCActivityLog.getLogFromObject({
-            _vcKey: '',
+            _vcKey: vcMetadata.getVcKey(),
             issuer: vcMetadata.issuer!!,
             credentialConfigurationId:
               selectedVc.verifiableCredential.credentialConfigurationId,


### PR DESCRIPTION
## Description

> Qr-login log was not showing up in vc activity log, vc key was not saved, which filtered out this log.

## Issue ticket number and link

> [INJIMOB-2575](https://mosip.atlassian.net/browse/INJIMOB-2575)


[INJIMOB-2575]: https://mosip.atlassian.net/browse/INJIMOB-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ