### PR TITLE
[INJIMOB-3027] add fallback if display property of credential type is missing

### DIFF
--- a/components/VC/common/VCUtils.tsx
+++ b/components/VC/common/VCUtils.tsx
@@ -259,7 +259,7 @@ export const getCredentialType = (
   if (supportedCredentialsWellknown.format === VCFormat.ldp_vc) {
     const types = supportedCredentialsWellknown.credential_definition
       .type as string[];
-    return types[1];
+    return types[types.length - 1];
   } else {
     return i18n.t('VcDetails:identityCard');
   }

--- a/components/openId4VCI/CredentialType.tsx
+++ b/components/openId4VCI/CredentialType.tsx
@@ -7,11 +7,12 @@ import {displayType} from '../../machines/Issuers/IssuersMachine';
 import {SvgImage} from '../ui/svg';
 import {getDisplayObjectForCurrentLanguage} from '../../shared/openId4VCI/Utils';
 import {CredentialTypes} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
+import { getCredentialType } from '../VC/common/VCUtils';
 
 export const CredentialType: React.FC<CredentialTypeProps> = props => {
   const selectedIssuerDisplayObject = props.item.display?.length
     ? getDisplayObjectForCurrentLanguage(props.item.display)
-    : {};
+    : {name:getCredentialType(props.item)};
 
   return (
     <Pressable
@@ -40,7 +41,7 @@ export const CredentialType: React.FC<CredentialTypeProps> = props => {
         <Text
           testID={`credentialTypeHeading-${props.testID}`}
           style={Theme.IssuersScreenStyles.issuerHeading}>
-          {selectedIssuerDisplayObject?.name}
+          {selectedIssuerDisplayObject.name as string}
         </Text>
       </View>
     </Pressable>


### PR DESCRIPTION
## Description

> if display property of credential type is missing we would fallback to `type` property for `name`.

## Issue ticket number and link

> Example : [INJIMOB-3027](https://mosip.atlassian.net/browse/INJIMOB-3027&#41)
.


[INJIMOB-3027]: https://mosip.atlassian.net/browse/INJIMOB-3027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ