### PR TITLE
[INJIMOB-2779] remove enable auth user input for ios workflows

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -74,14 +74,6 @@ on:
         options:
           - false
           - true
-      enable_auth:
-        description: 'Enable Authentication'
-        required: true
-        default: 'true'
-        type: choice
-        options:
-          - false
-          - true
 
 jobs:
   set-client-id:
@@ -140,7 +132,7 @@ jobs:
       APPLICATION_THEME: ${{ inputs.theme }}
       BUILD_DESCRIPTION: ${{ inputs.buildName }}
       ALLOW_ENV_EDIT: ${{ inputs.allow_env_edit }}
-      LIVENESS_DETECTION: ${{ inputs.liveness_detection }}
+      LIVENESS_DETECTION: 'false'
       APP_FLAVOR: ${{ inputs.injiFlavor }}
       SERVICE_LOCATION: '.'
       ANDROID_SERVICE_LOCATION: 'android'
@@ -166,7 +158,7 @@ jobs:
       TESTFLIGHT_BETA_APP_DESCRIPTION: ${{ inputs.buildName }}
       ALLOW_ENV_EDIT: ${{ inputs.allow_env_edit }}
       LIVENESS_DETECTION: ${{ inputs.liveness_detection }}
-      ENABLE_AUTH: ${{ inputs.enable_auth }}
+      ENABLE_AUTH: 'true'
       TESTFLIGHT_INTERNAL_TESTERS_GROUP: ${{ inputs.internal-testers }}
       APP_FLAVOR: ${{ inputs.injiFlavor }}
       SERVICE_LOCATION: '.'

--- a/.github/workflows/ios-custom-build.yml
+++ b/.github/workflows/ios-custom-build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       buildName:
-        description: 'Build App For'
+        description: 'Build App For UI Automation with Biometric-Off'
         required: true
         default: 'Sprint-x/QA-Inji/Release-x.x.x'
         type: string
@@ -46,14 +46,6 @@ on:
         options:
           - false
           - true
-      enable_auth:
-        description: 'Enable Authentication'
-        required: true
-        default: 'true'
-        type: choice
-        options:
-          - false
-          - true
 
 jobs:
   build-ios:
@@ -66,7 +58,7 @@ jobs:
       TESTFLIGHT_BETA_APP_DESCRIPTION: ${{ inputs.buildName }}
       ALLOW_ENV_EDIT: ${{ inputs.allow_env_edit }}
       LIVENESS_DETECTION: 'false'
-      ENABLE_AUTH: ${{ inputs.enable_auth }}
+      ENABLE_AUTH: 'false'
       TESTFLIGHT_INTERNAL_TESTERS_GROUP: 'Dev-testing'
       APP_FLAVOR: ${{ inputs.injiFlavor }}
       SERVICE_LOCATION: '.'


### PR DESCRIPTION
## Description

> remove enable auth user input for ios workflows

## Issue ticket number and link

> Example : [INJIMOB-2779](https://mosip.atlassian.net/browse/INJIMOB-2779&#41)



[INJIMOB-2779]: https://mosip.atlassian.net/browse/INJIMOB-2779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ