### PR TITLE
[INJIMOB-3154]:  Same device flow inOVP for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -78,6 +78,16 @@
             </intent-filter>
 
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                        android:scheme="openid4vp"
+                        android:host="authorize" />
+            </intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -75,12 +75,6 @@
                 <data
                     android:host="wla-auth"
                     android:scheme="io.mosip.residentapp.inji" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
                         android:scheme="openid4vp"

--- a/android/app/src/main/java/io/mosip/residentapp/InjiPackage.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiPackage.java
@@ -25,7 +25,7 @@ public class InjiPackage implements ReactPackage {
         modules.add(new RNVersionModule());
         modules.add(new RNWalletModule(new RNEventEmitter(reactApplicationContext), new Wallet(reactApplicationContext), reactApplicationContext));
         modules.add(new RNVerifierModule(new RNEventEmitter(reactApplicationContext), new Verifier(reactApplicationContext), reactApplicationContext));
-        modules.add(new RNQrLoginIntentModule(reactApplicationContext));
+        modules.add(new RNDeepLinkIntentModule(reactApplicationContext));
         modules.add(new InjiOpenID4VPModule(reactApplicationContext));
         modules.add(new RNVCVerifierModule(reactApplicationContext));
         return modules;

--- a/android/app/src/main/java/io/mosip/residentapp/IntentData.java
+++ b/android/app/src/main/java/io/mosip/residentapp/IntentData.java
@@ -2,6 +2,8 @@ package io.mosip.residentapp;
 
 public class IntentData {
     private String qrData = "";
+    private String ovpQrData = "";
+
     private static IntentData intentData;
     public static IntentData getInstance() {
         if(intentData == null)
@@ -16,4 +18,28 @@ public class IntentData {
         this.qrData = qrData;
     }
 
+    public String getOVPQrData() {
+        return ovpQrData;
+    }
+
+    public void setOVPQrData(String ovpQrData) {
+        this.ovpQrData = ovpQrData;
+    }
+
+    public String getDataByFlow(String flowType) {
+        if (flowType == null) return "";
+        return switch (flowType) {
+            case "qrLoginFlow" -> getQrData();
+            case "ovpFlow" -> getOVPQrData();
+            default -> "";
+        };
+    }
+
+    public void resetDataByFlow(String flowType) {
+        if (flowType == null) return;
+        switch (flowType) {
+            case "qrLoginFlow" -> setQrData("");
+            case "ovpFlow" -> setOVPQrData("");
+        }
+    }
 }

--- a/android/app/src/main/java/io/mosip/residentapp/MainActivity.java
+++ b/android/app/src/main/java/io/mosip/residentapp/MainActivity.java
@@ -43,20 +43,33 @@ public class MainActivity extends ReactActivity {
     setTheme(R.style.AppTheme);
     super.onCreate(null);
     Intent intent = getIntent();
-    readAndSetQRLoginIntentData(intent);
+    handleIntent(intent);
   }
 
   @Override
   public void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
-    readAndSetQRLoginIntentData(intent);
+    handleIntent(intent);
   }
 
-  private void readAndSetQRLoginIntentData(Intent intent){
+  private void handleIntent(Intent intent) {
+    if (intent == null || intent.getData() == null) return;
+
     Uri data = intent.getData();
-    if(data != null && Objects.equals(data.getScheme(), "io.mosip.residentapp.inji")){
-      IntentData intentData = IntentData.getInstance();
-      intentData.setQrData(String.valueOf(data));
+    String scheme = data.getScheme();
+    IntentData intentData = IntentData.getInstance();
+
+    if (scheme == null) return;
+
+    switch (scheme) {
+      case "io.mosip.residentapp.inji":
+        intentData.setQrData(data.toString());
+        break;
+      case "openid4vp":
+        intentData.setOVPQrData(data.toString());
+        break;
+      default:
+        break;
     }
   }
 

--- a/android/app/src/main/java/io/mosip/residentapp/RNDeepLinkIntentModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/RNDeepLinkIntentModule.java
@@ -5,24 +5,24 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
-public class RNQrLoginIntentModule extends ReactContextBaseJavaModule {
+public class RNDeepLinkIntentModule extends ReactContextBaseJavaModule {
 
 
   @Override
   public String getName() {
-    return "QrLoginIntent";
+    return "DeepLinkIntent";
   }
 
-  RNQrLoginIntentModule(ReactApplicationContext context) {
+  RNDeepLinkIntentModule(ReactApplicationContext context) {
     super(context);
   }
 
   @ReactMethod
-  public void isQrLoginByDeepLink(Promise promise) {
+  public void getDeepLinkIntentData(String flowType, Promise promise) {
     try {
-
       IntentData intentData = IntentData.getInstance();
-      promise.resolve(intentData.getQrData());
+      String result = intentData.getDataByFlow(flowType);
+      promise.resolve(result);
 
     } catch (Exception e) {
       promise.reject("E_UNKNOWN", e.getMessage());
@@ -30,9 +30,10 @@ public class RNQrLoginIntentModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void resetQRLoginDeepLinkData(){
-    IntentData intentData = IntentData.getInstance();
-    intentData.setQrData("");
+  public void resetDeepLinkIntentData(String flowType) {
+      IntentData intentData = IntentData.getInstance();
+      intentData.resetDataByFlow(flowType);
   }
 
 }
+

--- a/components/ui/Error.tsx
+++ b/components/ui/Error.tsx
@@ -1,5 +1,5 @@
 import {useFocusEffect} from '@react-navigation/native';
-import React, {Fragment} from 'react';
+import React, {Fragment, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {BackHandler, Dimensions, View} from 'react-native';
 import {ButtonProps as RNEButtonProps} from 'react-native-elements';
@@ -11,54 +11,70 @@ import {Modal} from './Modal';
 
 export const Error: React.FC<ErrorProps> = props => {
   const {t} = useTranslation('common');
-    const {
-        testID,
-        customStyles = {},
-        customImageStyles = {},
-        goBackType,
-        isModal = false,
-        isVisible,
-        showClose = true,
-        alignActionsOnEnd = false,
-        title,
-        message,
-        helpText,
-        image,
-        goBack,
-        goBackButtonVisible = false,
-        tryAgain,
-        onDismiss,
-        primaryButtonText,
-        primaryButtonEvent,
-        testIDTextButton,
-        textButtonText,
-        textButtonEvent,
-        primaryButtonTestID,
-        textButtonTestID,
-    } = props;
+  const {
+    testID,
+    customStyles = {},
+    customImageStyles = {},
+    goBackType,
+    isModal = false,
+    isVisible,
+    showClose = true,
+    alignActionsOnEnd = false,
+    title,
+    message,
+    helpText,
+    image,
+    goBack,
+    goBackButtonVisible = false,
+    tryAgain,
+    onDismiss,
+    primaryButtonText,
+    primaryButtonEvent,
+    testIDTextButton,
+    textButtonText,
+    textButtonEvent,
+    primaryButtonTestID,
+    textButtonTestID,
+  } = props;
+
+  const [triggerExitFlow, setTriggerExitFlow] = useState(false);
+
+  useEffect(() => {
+    if (
+      props.isVisible &&
+      props.textButtonText === undefined &&
+      props.primaryButtonText === undefined
+    ) {
+      const timeout = setTimeout(() => {
+        setTriggerExitFlow(true);
+      }, 2000);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [props.isVisible, props.textButtonText, props.primaryButtonText]);
+
+  useEffect(() => {
+    if (triggerExitFlow) {
+      props.textButtonEvent();
+      BackHandler.exitApp();
+    }
+  }, [triggerExitFlow]);
 
   const errorContent = () => {
     return (
       <Fragment>
         <View
-          style={[
-            {alignItems: 'center', marginHorizontal: 1},
-            customStyles,
-          ]}>
+          style={[{alignItems: 'center', marginHorizontal: 1}, customStyles]}>
           <View>
             <Row
               align="center"
               style={[Theme.ErrorStyles.image, customImageStyles]}>
               {image}
             </Row>
-            <Text
-              style={Theme.ErrorStyles.title}
-              testID={`${testID}Title`}>
+            <Text style={Theme.ErrorStyles.title} testID={`${testID}Title`}>
               {title}
             </Text>
-            <Text
-              style={Theme.ErrorStyles.message}
-              testID={`${testID}Message`}>
+            <Text style={Theme.ErrorStyles.message} testID={`${testID}Message`}>
               {message}
             </Text>
           </View>
@@ -69,9 +85,7 @@ export const Error: React.FC<ErrorProps> = props => {
                   onPress={primaryButtonEvent}
                   title={t(primaryButtonText)}
                   type={
-                    primaryButtonText === 'tryAgain'
-                      ? 'outline'
-                      : 'gradient'
+                    primaryButtonText === 'tryAgain' ? 'outline' : 'gradient'
                   }
                   width={
                     primaryButtonText === 'tryAgain'

--- a/machines/app.ts
+++ b/machines/app.ts
@@ -17,6 +17,7 @@ import {AppServices} from '../shared/GlobalContext';
 import {
   changeCrendetialRegistry,
   changeEsignetUrl,
+  DEEPLINK_FLOWS,
   ESIGNET_BASE_URL,
   isAndroid,
   isIOS,
@@ -41,7 +42,7 @@ import {
   generateKeyPairsAndStoreOrder,
 } from '../shared/cryptoutil/cryptoUtil';
 
-const QrLoginIntent = NativeModules.QrLoginIntent;
+const DeepLinkIntent = NativeModules.DeepLinkIntent;
 
 const model = createModel(
   {
@@ -51,6 +52,7 @@ const model = createModel(
     isDecryptError: false,
     isKeyInvalidateError: false,
     linkCode: '',
+    authorizationRequest: '',
   },
   {
     events: {
@@ -68,6 +70,7 @@ const model = createModel(
       STORE_RESPONSE: (response: unknown) => ({response}),
       RESET_KEY_INVALIDATE_ERROR_DISMISS: () => ({}),
       RESET_LINKCODE: () => ({}),
+      RESET_AUTHORIZATION_REQUEST: () => ({}),
       BIOMETRIC_CANCELLED: () => ({}),
     },
   },
@@ -93,6 +96,9 @@ export const appMachine = model.createMachine(
       },
       RESET_LINKCODE: {
         actions: ['resetLinkCode'],
+      },
+      RESET_AUTHORIZATION_REQUEST: {
+        actions: ['resetAuthorizationRequest'],
       },
       DECRYPT_ERROR_DISMISS: {
         actions: ['unsetIsDecryptError'],
@@ -215,13 +221,22 @@ export const appMachine = model.createMachine(
                 entry: ['forwardToServices'],
                 invoke: [
                   {
-                    src: 'isQrLoginByDeepLink',
+                    src: 'getQrLoginDeepLinkIntent',
                     onDone: {
                       actions: ['setLinkCode'],
                     },
                   },
                   {
-                    src: 'resetQRLoginDeepLinkData',
+                    src: 'resetQrLoginDeepLinkIntent',
+                  },
+                  {
+                    src: 'getOVPDeepLinkIntent',
+                    onDone: {
+                      actions: ['setAuthorizationRequest'],
+                    },
+                  },
+                  {
+                    src: 'resetOVPDeepLinkIntent',
                   },
                 ],
               },
@@ -266,7 +281,13 @@ export const appMachine = model.createMachine(
       resetLinkCode: assign({
         linkCode: '',
       }),
-      forwardToServices: pure((context, event) =>
+      setAuthorizationRequest: assign({
+        authorizationRequest: (_, event) => event.data || '',
+      }),
+      resetAuthorizationRequest: assign({
+        authorizationRequest: '',
+      }),
+      forwardToSerices: pure((context, event) =>
         Object.values(context.serviceRefs).map(serviceRef =>
           send({...event, type: `APP_${event.type}`}, {to: serviceRef}),
         ),
@@ -413,14 +434,26 @@ export const appMachine = model.createMachine(
     },
 
     services: {
-      isQrLoginByDeepLink: () => async () => {
-        const data = await QrLoginIntent.isQrLoginByDeepLink();
+      getQrLoginDeepLinkIntent: () => async () => {
+        const data = await DeepLinkIntent.getDeepLinkIntentData(
+          DEEPLINK_FLOWS.QR_LOGIN,
+        );
         return data;
       },
-      resetQRLoginDeepLinkData: () => async () => {
-        return await QrLoginIntent.resetQRLoginDeepLinkData();
+      resetQrLoginDeepLinkIntent: () => async () => {
+        return await DeepLinkIntent.resetDeepLinkIntentData(
+          DEEPLINK_FLOWS.QR_LOGIN,
+        );
       },
-
+      getOVPDeepLinkIntent: () => async () => {
+        const data = await DeepLinkIntent.getDeepLinkIntentData(
+          DEEPLINK_FLOWS.OVP,
+        );
+        return data;
+      },
+      resetOVPDeepLinkIntent: () => async () => {
+        return await DeepLinkIntent.resetDeepLinkIntentData(DEEPLINK_FLOWS.OVP);
+      },
       getAppInfo: () => async callback => {
         const appInfo = {
           deviceId: getDeviceId(),
@@ -533,4 +566,8 @@ export function selectIsKeyInvalidateError(state: State) {
 
 export function selectIsLinkCode(state: State) {
   return state.context.linkCode;
+}
+
+export function selectAuthorizationRequest(state: State) {
+  return state.context.authorizationRequest;
 }

--- a/machines/app.ts
+++ b/machines/app.ts
@@ -14,13 +14,12 @@ import {
 import {createScanMachine, scanMachine} from './bleShare/scan/scanMachine';
 import {pure, respond} from 'xstate/lib/actions';
 import {AppServices} from '../shared/GlobalContext';
+import {DEEPLINK_FLOWS} from '../shared/Utils';
 import {
   changeCrendetialRegistry,
   changeEsignetUrl,
-  DEEPLINK_FLOWS,
   ESIGNET_BASE_URL,
   isAndroid,
-  isIOS,
   MIMOTO_BASE_URL,
   SETTINGS_STORE_KEY,
 } from '../shared/constants';

--- a/machines/bleShare/scan/scanActions.ts
+++ b/machines/bleShare/scan/scanActions.ts
@@ -107,6 +107,7 @@ export const ScanActions = (model: any) => {
         encodedAuthRequest: context.linkCode,
         flowType: context.openID4VPFlowType,
         selectedVC: context.selectedVc,
+        isOVPViaDeepLink: context.isOVPViaDeepLink,
       }),
 
     openBluetoothSettings: () => {
@@ -290,6 +291,14 @@ export const ScanActions = (model: any) => {
 
     resetIsQrLoginViaDeepLink: assign({
       isQrLoginViaDeepLink: false,
+    }),
+
+    setIsOVPViaDeepLink: assign({
+      isOVPViaDeepLink: true,
+    }),
+
+    resetIsOVPViaDeepLink: assign({
+      isOVPViaDeepLink: false,
     }),
 
     setQuickShareData: assign({

--- a/machines/bleShare/scan/scanGuards.ts
+++ b/machines/bleShare/scan/scanGuards.ts
@@ -36,6 +36,7 @@ export const ScanGuards = () => {
       Boolean(event.data),
 
     isQrLoginViaDeepLinking: context => context.isQrLoginViaDeepLink === true,
+    isOVPViaDeepLink: context => context.isOVPViaDeepLink === true,
 
     isFlowTypeMiniViewShareWithSelfie: context =>
       context.flowType === VCShareFlowType.MINI_VIEW_SHARE_WITH_SELFIE,

--- a/machines/bleShare/scan/scanMachine.ts
+++ b/machines/bleShare/scan/scanMachine.ts
@@ -111,6 +111,10 @@ export const scanMachine =
                 target: 'restrictSharingVc',
               },
               {
+                cond: 'isOVPViaDeepLink',
+                target: '#scan.checkFaceAuthConsent',
+              },
+              {
                 target: 'startPermissionCheck',
               },
             ],
@@ -121,10 +125,6 @@ export const scanMachine =
         startPermissionCheck: {
           on: {
             START_PERMISSION_CHECK: [
-              {
-                cond: 'isOVPViaDeepLink',
-                target: '#scan.checkFaceAuthConsent',
-              },
               {
                 cond: 'uptoAndroid11',
                 target: '#scan.checkBluetoothPermission',

--- a/machines/bleShare/scan/scanMachine.ts
+++ b/machines/bleShare/scan/scanMachine.ts
@@ -73,6 +73,14 @@ export const scanMachine =
           ],
           target: '#scan.checkStorage',
         },
+        OVP_VIA_DEEP_LINK: {
+          actions: [
+            'setLinkCodeFromDeepLink',
+            'setIsOVPViaDeepLink',
+            'setOpenId4VPFlowType',
+          ],
+          target: '#scan.checkStorage',
+        },
       },
       states: {
         inactive: {
@@ -113,6 +121,10 @@ export const scanMachine =
         startPermissionCheck: {
           on: {
             START_PERMISSION_CHECK: [
+              {
+                cond: 'isOVPViaDeepLink',
+                target: '#scan.checkFaceAuthConsent',
+              },
               {
                 cond: 'uptoAndroid11',
                 target: '#scan.checkBluetoothPermission',
@@ -316,15 +328,19 @@ export const scanMachine =
           on: {
             STORE_RESPONSE: {
               actions: 'updateShowFaceAuthConsent',
-              target: '#scan.checkQrLoginViaDeepLink',
+              target: '#scan.checkForDeepLinkFlow',
             },
           },
         },
-        checkQrLoginViaDeepLink: {
+        checkForDeepLinkFlow: {
           always: [
             {
               cond: 'isQrLoginViaDeepLinking',
               target: '#scan.showQrLogin',
+            },
+            {
+              cond: 'isOVPViaDeepLink',
+              target: '#scan.startVPSharing',
             },
             {
               target: '#scan.findingConnection',
@@ -393,7 +409,7 @@ export const scanMachine =
             DISMISS: [
               {
                 cond: 'isFlowTypeSimpleShare',
-                actions: 'resetOpenID4VPFlowType',
+                actions: ['resetIsOVPViaDeepLink', 'resetOpenID4VPFlowType'],
                 target: 'checkStorage',
               },
               {

--- a/machines/bleShare/scan/scanModel.ts
+++ b/machines/bleShare/scan/scanModel.ts
@@ -61,6 +61,7 @@ const ScanEvents = {
   IN_PROGRESS: () => ({}),
   TIMEOUT: () => ({}),
   QRLOGIN_VIA_DEEP_LINK: (linkCode: string) => ({linkCode}),
+  OVP_VIA_DEEP_LINK: (linkCode: string) => ({linkCode}),
 };
 
 export const ScanModel = createModel(
@@ -81,8 +82,10 @@ export const ScanModel = createModel(
     OpenId4VPRef: {} as ActorRefFrom<typeof openID4VPMachine>,
     showQuickShareSuccessBanner: false,
     linkCode: '',
+    authorizationRequest: '',
     quickShareData: {},
     isQrLoginViaDeepLink: false,
+    isOVPViaDeepLink: false,
     showFaceAuthConsent: true as boolean,
     readyForBluetoothStateCheck: false,
     showFaceCaptureSuccessBanner: false,

--- a/machines/bleShare/scan/scanSelectors.ts
+++ b/machines/bleShare/scan/scanSelectors.ts
@@ -149,3 +149,7 @@ export function selectIsMinimumStorageRequiredForAuditEntryLimitReached(
 export function selectIsFaceVerificationConsent(state: State) {
   return state.matches('reviewing.faceVerificationConsent');
 }
+
+export function selectIsOVPViaDeepLink(state: State) {
+  return state.context.isOVPViaDeepLink;
+}

--- a/machines/openID4VP/openID4VPMachine.ts
+++ b/machines/openID4VP/openID4VPMachine.ts
@@ -46,6 +46,7 @@ export const openID4VPMachine = model.createMachine(
               'setFlowType',
               'setMiniViewShareSelectedVC',
               'setIsShareWithSelfie',
+              'setIsOVPViaDeepLink',
             ],
             target: 'checkFaceAuthConsent',
           },

--- a/machines/openID4VP/openID4VPModel.ts
+++ b/machines/openID4VP/openID4VPModel.ts
@@ -9,7 +9,8 @@ const openID4VPEvents = {
     encodedAuthRequest: string,
     flowType: string,
     selectedVC: any,
-  ) => ({encodedAuthRequest, flowType, selectedVC}),
+    isOVPViaDeepLink: boolean,
+  ) => ({encodedAuthRequest, flowType, selectedVC, isOVPViaDeepLink}),
   DOWNLOADED_VCS: (vcs: VC[]) => ({vcs}),
   SELECT_VC: (vcKey: string, inputDescriptorId: any) => ({
     vcKey,
@@ -66,6 +67,7 @@ export const openID4VPModel = createModel(
     isFaceVerificationRetryAttempt: false as boolean,
     requestedClaims: '' as string,
     showLoadingScreen: false as boolean,
+    isOVPViaDeepLink: false,
   },
   {events: openID4VPEvents},
 );

--- a/machines/openID4VP/openID4VPSelectors.ts
+++ b/machines/openID4VP/openID4VPSelectors.ts
@@ -2,7 +2,10 @@ import {StateFrom} from 'xstate';
 import {openID4VPMachine} from './openID4VPMachine';
 import {VCMetadata} from '../../shared/VCMetadata';
 import {getMosipLogo} from '../../components/VC/common/VCUtils';
-import {Credential, VerifiableCredentialData} from '../VerifiableCredential/VCMetaMachine/vc';
+import {
+  Credential,
+  VerifiableCredentialData,
+} from '../VerifiableCredential/VCMetaMachine/vc';
 
 type State = StateFrom<typeof openID4VPMachine>;
 
@@ -48,20 +51,23 @@ export function selectIsShowLoadingScreen(state: State) {
 
 export function selectCredentials(state: State) {
   const processCredential = (vcData: any) =>
-      vcData?.verifiableCredential?.credential ||
-      vcData?.verifiableCredential
-  let selectedCredentials: Credential[] = Object.values(state.context.selectedVCs)
-      .flatMap(innerMap => Object.values(innerMap)) // Extract arrays
-      .flat()
-      .map(processCredential);
+    vcData?.verifiableCredential?.credential || vcData?.verifiableCredential;
+  let selectedCredentials: Credential[] = Object.values(
+    state.context.selectedVCs,
+  )
+    .flatMap(innerMap => Object.values(innerMap)) // Extract arrays
+    .flat()
+    .map(processCredential);
   return selectCredentials.length === 0 ? undefined : selectedCredentials;
 }
 
 export function selectVerifiableCredentialsData(state: State) {
   let verifiableCredentialsData: VerifiableCredentialData[] = [];
-  let selectedCredentials: Credential[] = Object.values(state.context.selectedVCs)
-      .flatMap(innerMap => Object.values(innerMap))
-      .flat();
+  let selectedCredentials: Credential[] = Object.values(
+    state.context.selectedVCs,
+  )
+    .flatMap(innerMap => Object.values(innerMap))
+    .flat();
   selectedCredentials.map(vcData => {
     const vcMetadata = new VCMetadata(vcData.vcMetadata);
     verifiableCredentialsData.push({
@@ -69,12 +75,12 @@ export function selectVerifiableCredentialsData(state: State) {
       issuer: vcMetadata.issuer,
       issuerLogo: vcData?.verifiableCredential?.issuerLogo || getMosipLogo(),
       face:
-          vcData?.verifiableCredential?.credential?.credentialSubject?.face ||
-          vcData?.credential?.biometrics?.face,
+        vcData?.verifiableCredential?.credential?.credentialSubject?.face ||
+        vcData?.credential?.biometrics?.face,
       wellKnown: vcData?.verifiableCredential?.wellKnown,
       credentialTypes: vcData?.verifiableCredential?.credentialTypes,
     });
-    return verifiableCredentialsData
+    return verifiableCredentialsData;
   });
 
   return verifiableCredentialsData;
@@ -98,6 +104,10 @@ export function selectIsError(state: State) {
 
 export function selectOpenID4VPRetryCount(state: State) {
   return state.context.openID4VPRetryCount;
+}
+
+export function selectIsOVPViaDeeplink(state: State) {
+  return state.context.isOVPViaDeepLink;
 }
 
 export function selectIsFaceVerifiedInVPSharing(state: State) {

--- a/screens/MainLayout.tsx
+++ b/screens/MainLayout.tsx
@@ -20,7 +20,7 @@ import {Copilot} from '../components/ui/Copilot';
 import LinearGradient from 'react-native-linear-gradient';
 import {useNavigation} from '@react-navigation/native';
 import {useSelector} from '@xstate/react';
-import {selectIsLinkCode} from '../machines/app';
+import {selectAuthorizationRequest, selectIsLinkCode} from '../machines/app';
 import {BOTTOM_TAB_ROUTES} from '../routes/routesConstants';
 
 const {Navigator, Screen} = createBottomTabNavigator();
@@ -40,11 +40,16 @@ export const MainLayout: React.FC = () => {
 
   const linkCode = useSelector(appService, selectIsLinkCode);
 
+  const authorizationRequest = useSelector(
+    appService,
+    selectAuthorizationRequest,
+  );
+
   useEffect(() => {
-    if (linkCode != '') {
+    if (linkCode !== '' || authorizationRequest !== '') {
       navigation.navigate(BOTTOM_TAB_ROUTES.share);
     }
-  }, [linkCode]);
+  }, [linkCode, authorizationRequest]);
 
   return (
     <CopilotProvider

--- a/screens/Scan/ScanLayout.tsx
+++ b/screens/Scan/ScanLayout.tsx
@@ -164,13 +164,14 @@ export const ScanLayout: React.FC = () => {
       <SharingStatusModal
         isVisible={controller.isAccepted || controller.isVPSharingSuccess}
         testId={'sharingSuccessModal'}
-        buttonStatus={'homeAndHistoryIcons'}
+        buttonStatus={
+          controller.isOVPViaDeepLink ? 'none' : 'homeAndHistoryIcons'
+        }
         title={t('status.accepted.title')}
         message={t('status.accepted.message')}
         image={SvgImage.SuccessLogo()}
         goToHome={controller.GOTO_HOME}
         goToHistory={controller.GOTO_HISTORY}
-        hidebutton={controller.isOVPViaDeepLink}
       />
 
       {controller.errorStatusOverlay && (

--- a/screens/Scan/ScanLayout.tsx
+++ b/screens/Scan/ScanLayout.tsx
@@ -170,6 +170,7 @@ export const ScanLayout: React.FC = () => {
         image={SvgImage.SuccessLogo()}
         goToHome={controller.GOTO_HOME}
         goToHistory={controller.GOTO_HISTORY}
+        hidebutton={controller.isOVPViaDeepLink}
       />
 
       {controller.errorStatusOverlay && (

--- a/screens/Scan/ScanScreen.tsx
+++ b/screens/Scan/ScanScreen.tsx
@@ -80,9 +80,9 @@ export const ScanScreen: React.FC = () => {
       setTimeout(() => {
         OpenID4VP.initialize();
         OpenID4VP.sendErrorToVerifier(OVP_ERROR_MESSAGES.NO_MATCHING_VCS);
+        BackHandler.exitApp();
         scanScreenController.GOTO_HOME();
         appService.send(APP_EVENTS.RESET_AUTHORIZATION_REQUEST());
-        BackHandler.exitApp();
       }, 2000);
     }
   }, [

--- a/screens/Scan/ScanScreen.tsx
+++ b/screens/Scan/ScanScreen.tsx
@@ -361,7 +361,11 @@ export const ScanScreen: React.FC = () => {
           }
           primaryButtonEvent={sendVPScreenController.RETRY}
           textButtonTestID={'home'}
-          textButtonText={t('ScanScreen:status.accepted.home')}
+          textButtonText={
+            sendVPScreenController.isOVPViaDeepLink
+              ? undefined
+              : t('ScanScreen:status.accepted.home')
+          }
           textButtonEvent={handleTextButtonEvent}
           customImageStyles={{paddingBottom: 0, marginBottom: -6}}
           customStyles={{marginTop: '30%'}}

--- a/screens/Scan/ScanScreen.tsx
+++ b/screens/Scan/ScanScreen.tsx
@@ -63,7 +63,7 @@ export const ScanScreen: React.FC = () => {
   useEffect(() => {
     if (
       scanScreenController.isStartPermissionCheck &&
-      !scanScreenController.isEmpty
+      !scanScreenController.isNoSharableVCs
     )
       scanScreenController.START_PERMISSION_CHECK();
   });
@@ -74,7 +74,7 @@ export const ScanScreen: React.FC = () => {
 
   useEffect(() => {
     if (
-      scanScreenController.isEmpty &&
+      scanScreenController.isNoSharableVCs &&
       scanScreenController.authorizationRequest != ''
     ) {
       setTimeout(() => {
@@ -85,7 +85,10 @@ export const ScanScreen: React.FC = () => {
         BackHandler.exitApp();
       }, 2000);
     }
-  }, [scanScreenController.isEmpty, scanScreenController.authorizationRequest]);
+  }, [
+    scanScreenController.isNoSharableVCs,
+    scanScreenController.authorizationRequest,
+  ]);
 
   const openSettings = () => {
     Linking.openSettings();
@@ -199,7 +202,7 @@ export const ScanScreen: React.FC = () => {
   }
 
   function loadQRScanner() {
-    if (scanScreenController.isEmpty) {
+    if (scanScreenController.isNoSharableVCs) {
       return noShareableVcText();
     }
     if (scanScreenController.selectIsInvalid) {
@@ -239,7 +242,7 @@ export const ScanScreen: React.FC = () => {
 
   function displayStorageLimitReachedError(): React.ReactNode {
     return (
-      !scanScreenController.isEmpty && (
+      !scanScreenController.isNoSharableVCs && (
         <ErrorMessageOverlay
           testID="storageLimitReachedError"
           isVisible={
@@ -255,7 +258,7 @@ export const ScanScreen: React.FC = () => {
 
   function displayInvalidQRpopup(): React.ReactNode {
     return (
-      !scanScreenController.isEmpty && (
+      !scanScreenController.isNoSharableVCs && (
         <SharingStatusModal
           isVisible={scanScreenController.selectIsInvalid}
           testId={'invalidQrPopup'}

--- a/screens/Scan/ScanScreenController.ts
+++ b/screens/Scan/ScanScreenController.ts
@@ -27,6 +27,7 @@ import {selectIsMinimumStorageRequiredForAuditEntryLimitReached} from '../../mac
 import {BOTTOM_TAB_ROUTES} from '../../routes/routesConstants';
 import {MainBottomTabParamList} from '../../routes/routeTypes';
 import {useNavigation, NavigationProp} from '@react-navigation/native';
+import {selectAuthorizationRequest} from '../../machines/app';
 
 export function useScanScreen() {
   const {t} = useTranslation('ScanScreen');
@@ -113,5 +114,6 @@ export function useScanScreen() {
     ALLOWED,
     DENIED,
     isLocalPermissionRational,
+    authorizationRequest: useSelector(appService, selectAuthorizationRequest),
   };
 }

--- a/screens/Scan/ScanScreenController.ts
+++ b/screens/Scan/ScanScreenController.ts
@@ -81,9 +81,11 @@ export function useScanScreen() {
     scanService,
     selectIsLocationPermissionRationale,
   );
+  const isNoSharableVCs = !shareableVcsMetadata.length;
+
   return {
     locationError,
-    isEmpty: !shareableVcsMetadata.length,
+    isNoSharableVCs,
     isBluetoothPermissionDenied,
     isNearByDevicesPermissionDenied,
     isLocationDisabled,

--- a/screens/Scan/SendVPScreenController.ts
+++ b/screens/Scan/SendVPScreenController.ts
@@ -18,6 +18,7 @@ import {
   selectIsGetVCsSatisfyingAuthRequest,
   selectIsGetVPSharingConsent,
   selectIsInvalidIdentity,
+  selectIsOVPViaDeeplink,
   selectIsSelectingVcs,
   selectIsSharingVP,
   selectIsShowLoadingScreen,
@@ -267,6 +268,7 @@ export function useSendVPScreen() {
       openID4VPService,
       selectIsFaceVerificationConsent,
     ),
+    isOVPViaDeepLink: useSelector(openID4VPService, selectIsOVPViaDeeplink),
     credentials: useSelector(openID4VPService, selectCredentials),
     verifiableCredentialsData: useSelector(
       openID4VPService,

--- a/screens/Scan/SharingStatusModal.tsx
+++ b/screens/Scan/SharingStatusModal.tsx
@@ -1,15 +1,33 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Theme} from '../../components/ui/styleUtils';
 import {Modal} from '../../components/ui/Modal';
-import {Pressable, Dimensions, View} from 'react-native';
+import {Pressable, Dimensions, BackHandler} from 'react-native';
 import {Button, Column, Row, Text} from '../../components/ui';
 import testIDProps from '../../shared/commonUtil';
 import {SvgImage} from '../../components/ui/svg';
 
 export const SharingStatusModal: React.FC<SharingStatusModalProps> = props => {
   const {t} = useTranslation('ScanScreen');
+  const resetAndExit = () => {
+    BackHandler.exitApp();
+    props.goToHome();
+  };
 
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    if (props.isVisible && props.hidebutton === true) {
+      timeoutId = setTimeout(() => {
+        resetAndExit();
+      }, 2000);
+    }
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [props.isVisible, props.hidebutton]);
   return (
     <React.Fragment>
       <Modal
@@ -37,7 +55,7 @@ export const SharingStatusModal: React.FC<SharingStatusModalProps> = props => {
             {props.message}
           </Text>
         </Column>
-        {props.buttonStatus === 'homeAndHistoryIcons' ? (
+        {props.buttonStatus === 'homeAndHistoryIcons' && !props.hidebutton ? (
           <Row
             align="space-evenly"
             style={{marginBottom: Dimensions.get('screen').height * 0.06}}>
@@ -108,4 +126,5 @@ interface SharingStatusModalProps {
   goToHistory?: () => void;
   onGradientButton?: () => void;
   onClearButton?: () => void;
+  hidebutton?: boolean;
 }

--- a/screens/Scan/SharingStatusModal.tsx
+++ b/screens/Scan/SharingStatusModal.tsx
@@ -17,7 +17,7 @@ export const SharingStatusModal: React.FC<SharingStatusModalProps> = props => {
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | undefined;
 
-    if (props.isVisible && props.hidebutton === true) {
+    if (props.isVisible && props.buttonStatus === 'none') {
       timeoutId = setTimeout(() => {
         resetAndExit();
       }, 2000);
@@ -27,7 +27,7 @@ export const SharingStatusModal: React.FC<SharingStatusModalProps> = props => {
         clearTimeout(timeoutId);
       }
     };
-  }, [props.isVisible, props.hidebutton]);
+  }, [props.isVisible, props.buttonStatus]);
   return (
     <React.Fragment>
       <Modal
@@ -55,7 +55,7 @@ export const SharingStatusModal: React.FC<SharingStatusModalProps> = props => {
             {props.message}
           </Text>
         </Column>
-        {props.buttonStatus === 'homeAndHistoryIcons' && !props.hidebutton ? (
+        {props.buttonStatus === 'homeAndHistoryIcons' ? (
           <Row
             align="space-evenly"
             style={{marginBottom: Dimensions.get('screen').height * 0.06}}>
@@ -126,5 +126,4 @@ interface SharingStatusModalProps {
   goToHistory?: () => void;
   onGradientButton?: () => void;
   onClearButton?: () => void;
-  hidebutton?: boolean;
 }

--- a/screens/Scan/SharingStatusModal.tsx
+++ b/screens/Scan/SharingStatusModal.tsx
@@ -116,7 +116,7 @@ export const SharingStatusModal: React.FC<SharingStatusModalProps> = props => {
 interface SharingStatusModalProps {
   isVisible: boolean;
   testId: string;
-  buttonStatus?: String;
+  buttonStatus?: 'homeAndHistoryIcons' | 'none';
   title: String;
   message: String;
   image: React.ReactElement;

--- a/shared/Utils.ts
+++ b/shared/Utils.ts
@@ -73,3 +73,8 @@ export const formatTextWithGivenLimit = (value: string, limit: number = 15) => {
   }
   return value;
 };
+
+export enum DEEPLINK_FLOWS {
+    QR_LOGIN = 'qrLoginFlow',
+    OVP = 'ovpFlow',
+}

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -168,3 +168,13 @@ export const FACE_SDK_MODEL_CHECKSUM =
 export const EXPIRED_VC_ERROR_CODE = 'ERR_VC_EXPIRED';
 
 export const BASE_36 = 36;
+
+export const OVP_ERROR_MESSAGES = {
+  NO_MATCHING_VCS: 'No matching credentials found to fulfill the request.',
+  DECLINED: 'The user has declined to share their credentials at this time.',
+};
+
+export const DEEPLINK_FLOWS = {
+  QR_LOGIN: 'qrLoginFlow',
+  OVP: 'ovpFlow',
+};

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -173,8 +173,3 @@ export const OVP_ERROR_MESSAGES = {
   NO_MATCHING_VCS: 'No matching credentials found to fulfill the request.',
   DECLINED: 'The user has declined to share their credentials at this time.',
 };
-
-export const DEEPLINK_FLOWS = {
-  QR_LOGIN: 'qrLoginFlow',
-  OVP: 'ovpFlow',
-};


### PR DESCRIPTION
Features added in Same device flow:

- Deeplink clicked from Browser/ Verifier in android.
- Through Intent Data, redirecting to Share screen of Wallet App installed inside the device.
- If matchingVCs are available, show list of matching VCs to share. After sharing the VC successfully, in success screen after 2 seconds delay, redirect back to Verifier.
- If user clicks on close icon or Reject button or declines the user consent, redirect back to Verifier.
- If no matchingVCs are available, show error screen and after 2 seconds delay, redirect back to Verifier.
- If no cards are available, show "No shareable cards available" screen and after 2 seconds delay, redirect back to Verifier.

- For all the above scenarios, Wallet should send success or error response when redirecting back to Verifier.

[INJIMOB-3154](https://mosip.atlassian.net/browse/INJIMOB-3154)




[INJIMOB-3154]: https://mosip.atlassian.net/browse/INJIMOB-3154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ