### PR TITLE
[INJIMOB-2977]:fix alignment issue in static screens of intro sliders

### DIFF
--- a/screens/IntroSliders/backupRestoreIntro.tsx
+++ b/screens/IntroSliders/backupRestoreIntro.tsx
@@ -36,6 +36,8 @@ const StaticBackupAndRestoreScreen: React.FC = () => {
                         style={{
                             fontSize: 16,
                             color: Theme.Colors.blackIcon,
+                            paddingTop:5,
+                            maxWidth:185
                         }}
                         testID="screenTitle">
                         {t('title')}
@@ -51,7 +53,7 @@ const StaticBackupAndRestoreScreen: React.FC = () => {
                                     <View
                                         testID="helpIcon"
                                         style={Theme.HelpScreenStyle.iconStyle}>
-                                        {SvgImage.info()}
+                                        {SvgImage.coloredInfo()}
                                     </View>
                                     <Text
                                         testID="helpText"

--- a/screens/IntroSliders/secureShareIntro.tsx
+++ b/screens/IntroSliders/secureShareIntro.tsx
@@ -44,7 +44,7 @@ export const StaticSendVcScreen: React.FC = () => {
                 <Text 
                     testID="introTitle" 
                     weight="bold" 
-                    size="large">
+                    size="small">
                     {t("SendVcScreen:introTitle")}
                 </Text>
             </Row>
@@ -52,7 +52,7 @@ export const StaticSendVcScreen: React.FC = () => {
                 <Text 
                     testID="issuerName" 
                     color={Theme.Colors.GrayText} 
-                    size="extraSmall">
+                    size="smaller">
                     Philippines Government
                 </Text>
             </Row>
@@ -77,6 +77,7 @@ export const StaticSendVcScreen: React.FC = () => {
                 testID="pleaseSelectAnId"
                 margin="0 0 8 16"
                 weight="bold"
+                size = "small"
                 color={Theme.Colors.textValue}
                 style={{ position: 'relative' }}>
                 {t("SendVcScreen:pleaseSelectAnId")}


### PR DESCRIPTION
In the Introsliders when the user selects the preferred language as the tamil or kannada there was some alignment issues in the backup screen and sendvc screen 
![Screenshot_2025-04-14-15-29-32-57_fba87592218da393460b8e128d2f49dd](https://github.com/user-attachments/assets/82c3a8e1-2c88-4f65-82b6-827cb318cc88)
![Screenshot_2025-04-14-15-29-36-18_fba87592218da393460b8e128d2f49dd](https://github.com/user-attachments/assets/5ccf7661-7382-4723-9c00-9e59369a0d53)
![Screenshot_2025-04-14-15-29-39-14_fba87592218da393460b8e128d2f49dd](https://github.com/user-attachments/assets/3d6668fe-8186-49c7-bee8-dc3030c13fa5)
![Screenshot_2025-04-14-15-30-10-92_fba87592218da393460b8e128d2f49dd](https://github.com/user-attachments/assets/1b3c87f1-f3fe-4cfd-9430-7bb901d1bb75)
![Screenshot_2025-04-14-15-30-15-17_fba87592218da393460b8e128d2f49dd](https://github.com/user-attachments/assets/392b17b7-3e81-4cc0-922b-888057be1f5e)

