### PR TITLE
[INJIMOB-3129] handle long client name consent

### DIFF
--- a/machines/openID4VP/openID4VPModel.ts
+++ b/machines/openID4VP/openID4VPModel.ts
@@ -1,9 +1,6 @@
 import {createModel} from 'xstate/lib/model';
 import {AppServices} from '../../shared/GlobalContext';
-import {
-  SelectedCredentialsForVPSharing,
-  VC,
-} from '../VerifiableCredential/VCMetaMachine/vc';
+import {VC} from '../VerifiableCredential/VCMetaMachine/vc';
 import {KeyTypes} from '../../shared/cryptoutil/KeyTypes';
 import {VPActivityLogType} from '../../components/VPShareActivityLogEvent';
 

--- a/machines/openID4VP/openID4VPModel.ts
+++ b/machines/openID4VP/openID4VPModel.ts
@@ -1,6 +1,9 @@
 import {createModel} from 'xstate/lib/model';
 import {AppServices} from '../../shared/GlobalContext';
-import {SelectedCredentialsForVPSharing, VC} from '../VerifiableCredential/VCMetaMachine/vc';
+import {
+  SelectedCredentialsForVPSharing,
+  VC,
+} from '../VerifiableCredential/VCMetaMachine/vc';
 import {KeyTypes} from '../../shared/cryptoutil/KeyTypes';
 import {VPActivityLogType} from '../../components/VPShareActivityLogEvent';
 
@@ -50,7 +53,7 @@ export const openID4VPModel = createModel(
     authenticationResponse: {},
     vcsMatchingAuthRequest: {} as Record<string, VC[]>,
     checkedAll: false as boolean,
-    selectedVCs: {} as SelectedCredentialsForVPSharing,
+    selectedVCs: {} as Record<string, VC[]>,
     isShareWithSelfie: false as boolean,
     showFaceAuthConsent: true as boolean,
     purpose: '' as string,

--- a/screens/Scan/SendVPScreen.tsx
+++ b/screens/Scan/SendVPScreen.tsx
@@ -222,6 +222,7 @@ export const SendVPScreen: React.FC<ScanLayoutProps> = props => {
                   onPress={controller.ACCEPT_REQUEST}
                 />
               )}
+              {/*If one of the selected vc has image, it needs to sent only after biometric authentication (Share with Selfie)*/}
               {controller.checkIfAnyVCHasImage(
                 controller.vcsMatchingAuthRequest,
               ) && (

--- a/screens/Scan/SendVPScreenController.ts
+++ b/screens/Scan/SendVPScreenController.ts
@@ -35,7 +35,7 @@ import {selectShareableVcs} from '../../machines/VerifiableCredential/VCMetaMach
 import {RootRouteProps} from '../../routes';
 import {BOTTOM_TAB_ROUTES} from '../../routes/routesConstants';
 import {GlobalContext} from '../../shared/GlobalContext';
-import {isMosipVC} from '../../shared/Utils';
+import {formatForDisplay, isMosipVC} from '../../shared/Utils';
 import {VCMetadata} from '../../shared/VCMetadata';
 import {VPShareOverlayProps} from './VPShareOverlay';
 import {ActivityLogEvents} from '../../machines/activityLog';
@@ -225,7 +225,7 @@ export function useSendVPScreen() {
       title: t('consentDialog.title'),
       titleTestID: 'consentTitle',
       message: t('consentDialog.message', {
-        verifierName: vpVerifierName,
+        verifierName: formatForDisplay(vpVerifierName),
         interpolation: {escapeValue: false},
       }),
       messageTestID: 'consentMsg',

--- a/screens/Scan/SendVPScreenController.ts
+++ b/screens/Scan/SendVPScreenController.ts
@@ -6,7 +6,10 @@ import {ActorRefFrom} from 'xstate';
 import {Theme} from '../../components/ui/styleUtils';
 import {selectIsCancelling} from '../../machines/bleShare/commonSelectors';
 import {ScanEvents} from '../../machines/bleShare/scan/scanMachine';
-import {selectFlowType, selectIsSendingVPError,} from '../../machines/bleShare/scan/scanSelectors';
+import {
+  selectFlowType,
+  selectIsSendingVPError,
+} from '../../machines/bleShare/scan/scanSelectors';
 import {
   selectAreAllVCsChecked,
   selectCredentials,
@@ -40,7 +43,7 @@ import {VCMetadata} from '../../shared/VCMetadata';
 import {VPShareOverlayProps} from './VPShareOverlay';
 import {ActivityLogEvents} from '../../machines/activityLog';
 import {VPShareActivityLog} from '../../components/VPShareActivityLogEvent';
-import {SelectedCredentialsForVPSharing} from "../../machines/VerifiableCredential/VCMetaMachine/vc";
+import {SelectedCredentialsForVPSharing} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
 
 type MyVcsTabNavigation = NavigationProp<RootRouteProps>;
 
@@ -97,22 +100,14 @@ export function useSendVPScreen() {
     return hasImage;
   };
 
-  const getSelectedVCs = () => {
-    const selectedVcsData: SelectedCredentialsForVPSharing = {};
-    Object.entries(selectedVCKeys).map(([vcKey, inputDescriptorId]) => {
+  const getSelectedVCs = (): Record<string, any[]> => {
+    let selectedVcsData: Record<string, any[]> = {};
+    Object.entries(selectedVCKeys).forEach(([vcKey, inputDescriptorId]) => {
       const vcData = myVcs[vcKey];
-        const credentialFormat = vcData.format;
-      if (selectedVcsData.hasOwnProperty(inputDescriptorId)) {
-        let matchingVcsOfInputDescriptor = selectedVcsData[inputDescriptorId]
-        if (matchingVcsOfInputDescriptor.hasOwnProperty(credentialFormat)) {
-          matchingVcsOfInputDescriptor[credentialFormat] = [...matchingVcsOfInputDescriptor[credentialFormat], vcData]
-        } else {
-          matchingVcsOfInputDescriptor[credentialFormat] = [vcData]
-        }
-        selectedVcsData[inputDescriptorId] = matchingVcsOfInputDescriptor
-      } else {
-        selectedVcsData[inputDescriptorId] = {[credentialFormat]: [vcData]}
+      if (!selectedVcsData[inputDescriptorId]) {
+        selectedVcsData[inputDescriptorId] = [];
       }
+      selectedVcsData[inputDescriptorId].push(vcData);
     });
     return selectedVcsData;
   };

--- a/screens/Scan/SendVPScreenController.ts
+++ b/screens/Scan/SendVPScreenController.ts
@@ -38,7 +38,7 @@ import {selectShareableVcs} from '../../machines/VerifiableCredential/VCMetaMach
 import {RootRouteProps} from '../../routes';
 import {BOTTOM_TAB_ROUTES} from '../../routes/routesConstants';
 import {GlobalContext} from '../../shared/GlobalContext';
-import {formatForDisplay, isMosipVC} from '../../shared/Utils';
+import {formatTextWithGivenLimit, isMosipVC} from '../../shared/Utils';
 import {VCMetadata} from '../../shared/VCMetadata';
 import {VPShareOverlayProps} from './VPShareOverlay';
 import {ActivityLogEvents} from '../../machines/activityLog';
@@ -217,7 +217,7 @@ export function useSendVPScreen() {
       title: t('consentDialog.title'),
       titleTestID: 'consentTitle',
       message: t('consentDialog.message', {
-        verifierName: formatForDisplay(vpVerifierName),
+        verifierName: formatTextWithGivenLimit(vpVerifierName),
         interpolation: {escapeValue: false},
       }),
       messageTestID: 'consentMsg',

--- a/screens/Scan/SendVPScreenController.ts
+++ b/screens/Scan/SendVPScreenController.ts
@@ -43,7 +43,6 @@ import {VCMetadata} from '../../shared/VCMetadata';
 import {VPShareOverlayProps} from './VPShareOverlay';
 import {ActivityLogEvents} from '../../machines/activityLog';
 import {VPShareActivityLog} from '../../components/VPShareActivityLogEvent';
-import {SelectedCredentialsForVPSharing} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
 
 type MyVcsTabNavigation = NavigationProp<RootRouteProps>;
 
@@ -85,19 +84,17 @@ export function useSendVPScreen() {
   );
 
   const checkIfAnyVCHasImage = vcs => {
-    const hasImage = Object.values(vcs)
+    return Object.values(vcs)
       .flatMap(vc => vc)
       .some(vc => {
         return isMosipVC(vc.vcMetadata?.issuer);
       });
-    return hasImage;
   };
 
   const checkIfAllVCsHasImage = vcs => {
-    const hasImage = Object.values(vcs)
+    return Object.values(vcs)
       .flatMap(vc => vc)
       .every(vc => isMosipVC(vc.vcMetadata.issuer));
-    return hasImage;
   };
 
   const getSelectedVCs = (): Record<string, any[]> => {
@@ -295,8 +292,8 @@ export function useSendVPScreen() {
     SELECT_VC_ITEM:
       (vcKey: string, inputDescriptorId: string) =>
       (vcRef: ActorRefFrom<typeof VCItemMachine>) => {
-        var selectedVcs = {...selectedVCKeys};
-        var isVCSelected = !!!selectedVcs[vcKey];
+        let selectedVcs = {...selectedVCKeys};
+        const isVCSelected = !!!selectedVcs[vcKey];
         if (isVCSelected) {
           selectedVcs[vcKey] = inputDescriptorId;
         } else {
@@ -312,7 +309,7 @@ export function useSendVPScreen() {
     },
 
     CHECK_ALL: () => {
-      var updatedVCsList = {};
+      let updatedVCsList = {};
       Object.entries(vcsMatchingAuthRequest).map(([inputDescriptorId, vcs]) => {
         vcs.map(vcData => {
           const vcKey = VCMetadata.fromVcMetadataString(

--- a/shared/Utils.ts
+++ b/shared/Utils.ts
@@ -67,10 +67,9 @@ export class UUID {
   }
 }
 
-export const formatForDisplay = (value: String)=> {
-  const limit = 15;
+export const formatTextWithGivenLimit = (value: string, limit: number = 15) => {
   if (value.length > limit) {
     return value.substring(0, limit) + '...';
   }
   return value;
-}
+};

--- a/shared/Utils.ts
+++ b/shared/Utils.ts
@@ -66,3 +66,11 @@ export class UUID {
     return uuid();
   }
 }
+
+export const formatForDisplay = (value: String)=> {
+  const limit = 15;
+  if (value.length > limit) {
+    return value.substring(0, limit) + '...';
+  }
+  return value;
+}


### PR DESCRIPTION
## Description

For OVP flow, when sharing the VP a consent is shown to the user, if the client name is too long, it is trimmed and shown in the consent page

## Issue ticket number and link

> [INJIMOB-3129](https://mosip.atlassian.net/browse/INJIMOB-3129&#41)

## Screenshots

#### iOS
<img width="326" alt="Screenshot 2025-04-15 at 7 33 08 PM" src="https://github.com/user-attachments/assets/df3e47fd-e695-44d4-86e9-02c26928aa32" />

#### Android
![image](https://github.com/user-attachments/assets/07fcabd7-2cf4-47bb-9788-81534547ad45)



[INJIMOB-3129]: https://mosip.atlassian.net/browse/INJIMOB-3129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ