### PR TITLE
[INJIMOB-3080] Fix page not found in Help Screen

### DIFF
--- a/shared/InitialConfig.ts
+++ b/shared/InitialConfig.ts
@@ -15,7 +15,7 @@ export const INITIAL_CONFIG = {
     allowedAuthType: 'demo,otp,bio-Finger,bio-Iris,bio-Face',
     allowedEkycAuthType: 'demo,otp,bio-Finger,bio-Iris,bio-Face',
     warningDomainName: '',
-    aboutInjiUrl: 'https://docs.mosip.io/inji',
+    aboutInjiUrl: 'https://docs.mosip.io/inji/inji-wallet/inji-mobile',
     faceSdkModelUrl: '',
     openId4VCIDownloadVCTimeout: '30000',
   },


### PR DESCRIPTION
The page not found issue was due to the change in inji docs url that has been fixed now 