### PR TITLE
[INJIMOB-0.16.x] select xcode16.2 for ios-app publish

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,4 +1,4 @@
-xcode_select '/Applications/Xcode_15.0.1.app'
+xcode_select '/Applications/Xcode_16.2.app'
 
 default_platform(:ios)
 APP_STORE_CONNECT_TEAM_ID = ENV["APP_STORE_CONNECT_TEAM_ID"]


### PR DESCRIPTION
## Description

> change xcode version to 16.2 in ios/fastfile for new minimum required dependency of sdk ios 18.

