### PR TITLE
[INJIMOB-3188]: QR consent claims display text updates

### DIFF
--- a/.env
+++ b/.env
@@ -2,9 +2,9 @@
 # eg . npm build android:newlogic --reset-cache
 
 #MIMOTO_HOST=http://mock.mimoto.newlogic.dev
-MIMOTO_HOST=https://api.qa-inji.mosip.net
+MIMOTO_HOST=https://api.iom.mosip.net
 
-ESIGNET_HOST=https://esignet.qa-inji.mosip.net
+ESIGNET_HOST=https://esignet.iom.mosip.net
 
 OBSRV_HOST = https://dataset-api.telemetry.mosip.net
 

--- a/.talismanrc
+++ b/.talismanrc
@@ -200,7 +200,7 @@ fileignoreconfig:
   - filename: screens/Home/IntroSlidersScreen.tsx
     checksum: e893b77e3858b9bbe623c0bbdac99f05760fcf8196af5710be177509bb4c207d
   - filename: .env
-    checksum: f8375c44b0e70e691f942ea3323a0bf12cb0e2a7653a5551b34e2403a47119a8
+    checksum: bc67aefaf61251c4edd400d02a35dbcc27b8072f34231be4daa3144713d1e8a9
   - filename: machines/VCItemMachine/VCItemMachine.typegen.ts
     checksum: 850b5d02636bef9e286fc0fbc4ffffbd38068f332c319302a906496f4bc1c8a1
   - filename: machines/VerifiableCredential/VCItemMachine/VCItemModel.ts

--- a/screens/QrLogin/QrConsent.tsx
+++ b/screens/QrLogin/QrConsent.tsx
@@ -9,6 +9,7 @@ import {Modal} from '../../components/ui/Modal';
 import {QrLoginRef} from '../../machines/QrLogin/QrLoginMachine';
 import {ScrollView} from 'react-native';
 import {getClientNameForCurrentLanguage} from '../../i18n';
+import {CLAIM_DISPLAY_NAMES} from '../../shared/constants';
 
 export const QrConsent: React.FC<QrConsentProps> = props => {
   const {t} = useTranslation('QrLogin');
@@ -60,9 +61,15 @@ export const QrConsent: React.FC<QrConsentProps> = props => {
                 <Text
                   color={Theme.Colors.Details}
                   style={Theme.TextStyles.base}>
-                  {t(claim[0].toUpperCase() + claim.slice(1))
-                    .split('_')
-                    .join(' ')}
+                  {t(
+                    CLAIM_DISPLAY_NAMES[claim] ||
+                      claim
+                        .split('_')
+                        .map(
+                          word => word.charAt(0).toUpperCase() + word.slice(1),
+                        )
+                        .join(' '),
+                  )}
                 </Text>
                 <Text
                   color={Theme.Colors.GrayIcon}
@@ -93,9 +100,16 @@ export const QrConsent: React.FC<QrConsentProps> = props => {
                 <ListItem.Content>
                   <ListItem.Title>
                     <Text color={Theme.Colors.Details}>
-                      {t(claim[0].toUpperCase() + claim.slice(1))
-                        .split('_')
-                        .join(' ')}
+                      {t(
+                        CLAIM_DISPLAY_NAMES[claim] ||
+                          claim
+                            .split('_')
+                            .map(
+                              word =>
+                                word.charAt(0).toUpperCase() + word.slice(1),
+                            )
+                            .join(' '),
+                      )}
                     </Text>
                   </ListItem.Title>
                 </ListItem.Content>

--- a/screens/QrLogin/QrConsent.tsx
+++ b/screens/QrLogin/QrConsent.tsx
@@ -9,7 +9,7 @@ import {Modal} from '../../components/ui/Modal';
 import {QrLoginRef} from '../../machines/QrLogin/QrLoginMachine';
 import {ScrollView} from 'react-native';
 import {getClientNameForCurrentLanguage} from '../../i18n';
-import {CLAIM_DISPLAY_NAMES} from '../../shared/constants';
+import {ACRONYMS} from '../../shared/constants';
 
 export const QrConsent: React.FC<QrConsentProps> = props => {
   const {t} = useTranslation('QrLogin');
@@ -62,13 +62,15 @@ export const QrConsent: React.FC<QrConsentProps> = props => {
                   color={Theme.Colors.Details}
                   style={Theme.TextStyles.base}>
                   {t(
-                    CLAIM_DISPLAY_NAMES[claim] ||
-                      claim
-                        .split('_')
-                        .map(
-                          word => word.charAt(0).toUpperCase() + word.slice(1),
-                        )
-                        .join(' '),
+                    claim
+                      .split('_')
+                      .map(word => {
+                        const lower = word.toLowerCase();
+                        return ACRONYMS.has(lower)
+                          ? lower.toUpperCase()
+                          : word.charAt(0).toUpperCase() + word.slice(1);
+                      })
+                      .join(' '),
                   )}
                 </Text>
                 <Text
@@ -101,14 +103,15 @@ export const QrConsent: React.FC<QrConsentProps> = props => {
                   <ListItem.Title>
                     <Text color={Theme.Colors.Details}>
                       {t(
-                        CLAIM_DISPLAY_NAMES[claim] ||
-                          claim
-                            .split('_')
-                            .map(
-                              word =>
-                                word.charAt(0).toUpperCase() + word.slice(1),
-                            )
-                            .join(' '),
+                        claim
+                          .split('_')
+                          .map(word => {
+                            const lower = word.toLowerCase();
+                            return ACRONYMS.has(lower)
+                              ? lower.toUpperCase()
+                              : word.charAt(0).toUpperCase() + word.slice(1);
+                          })
+                          .join(' '),
                       )}
                     </Text>
                   </ListItem.Title>

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -173,12 +173,4 @@ export const BASE_36 = 36;
 
 export const DEFAULT_OTP = '111111';
 
-export const CLAIM_DISPLAY_NAMES = {
-  first_name: 'First Name',
-  last_name: 'Last Name',
-  national_id: 'National ID',
-  birthdate: 'Date of Birth',
-  email: 'Email ID',
-  picture: 'Photo',
-  gender: 'Gender',
-};
+export const ACRONYMS = new Set(['id']);

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -172,3 +172,13 @@ export const EXPIRED_VC_ERROR_CODE = 'ERR_VC_EXPIRED';
 export const BASE_36 = 36;
 
 export const DEFAULT_OTP = '111111';
+
+export const CLAIM_DISPLAY_NAMES = {
+  first_name: 'First Name',
+  last_name: 'Last Name',
+  national_id: 'National ID',
+  birthdate: 'Date of Birth',
+  email: 'Email ID',
+  picture: 'Photo',
+  gender: 'Gender',
+};


### PR DESCRIPTION
- Captalize the field name. For eg: first_name will be displayed as First Name
- Maintaining `id` in acronym set in constants file for exception case to captialize to `ID`. So that, `national_id` will be displayed as `National ID`