### PR TITLE
[INJIMOB-3455] chore: update ovp lib version

### DIFF
--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -70,7 +70,7 @@
       "location" : "https://github.com/mosip/inji-openid4vp-ios-swift.git",
       "state" : {
         "branch" : "develop",
-        "revision" : "ca4935478360f45dd20444eac5d6bae9affc6d36"
+        "revision" : "5f68487428d6e5f1fb4876d8245da12bac73861b"
       }
     },
     {


### PR DESCRIPTION
Changes of libray
- handle request uri response to be JWT
- For redirect_uri client id scheme, requets uri is not applicable


